### PR TITLE
zephyr: CMakeLists.txt: support nrfjprog mass erase flag

### DIFF
--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -53,6 +53,7 @@ macro(app_set_runner_args)
   if(CONFIG_ZEPHYR_TRY_MASS_ERASE)
     board_runner_args(dfu-util "--dfuse-modifiers=force:mass-erase")
     board_runner_args(pyocd "--flashtool-opt=-ce")
+    board_runner_args(nrfjprog "--erase")
   endif()
 endmacro()
 


### PR DESCRIPTION
NOTE: depends on https://github.com/zephyrproject-rtos/zephyr/pull/6809 -- DO NOT MERGE unless that's merged as well

The upstream Zephyr runner for nrfjprog now supports an --erase
toggle, which controls whether a mass-erase is done. Add that to its
invocation when CONF_ZEPHYR_TRY_MASS_ERASE is given, just like is done
for dfu-util and pyocd.
