### PR TITLE
Fix main github repo links in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # [mcuboot](http://mcuboot.com/)
 
 [![Coverity Scan Build Status](https://scan.coverity.com/projects/12307/badge.svg)][coverity]
-[![Build/Test](https://img.shields.io/travis/runtimeco/mcuboot/master.svg?label=travis-ci)][travis]
+[![Build/Test](https://img.shields.io/travis/JuulLabs-OSS/mcuboot/master.svg?label=travis-ci)][travis]
 
 [coverity]: https://scan.coverity.com/projects/mcuboot
-[travis]: https://travis-ci.org/runtimeco/mcuboot
+[travis]: https://travis-ci.org/JuulLabs-OSS/mcuboot
 
 This is mcuboot, version 1.2.0
 
@@ -31,7 +31,7 @@ Instructions for different operating systems can be found here:
 The issues being planned and worked on are tracked using GitHub issues. To
 participate please visit:
 
-[MCUBoot GitHub Issues](https://github.com/runtimeco/mcuboot/issues)
+[MCUBoot GitHub Issues](https://github.com/JuulLabs-OSS/mcuboot/issues)
 
 ~~Issues were previously tracked on [MCUboot JIRA](https://runtimeco.atlassian.net/projects/MCUB/summary)
 , but it is now deprecated.~~

--- a/docs/SubmittingPatches.md
+++ b/docs/SubmittingPatches.md
@@ -1,7 +1,7 @@
 # Submitting Patches
 
 Development on mcuboot primarily takes place in github, at:
-https://github.com/runtimeco/mcuboot
+https://github.com/JuulLabs-OSS/mcuboot
 
 Changes should be submitted via github pull requests.  Each commit
 should have a Signed-off-by line for the author (and the committer, if

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ of date.  You should use `imgtool.py` instead of these documents.
 The issues being planned and worked on are tracked using GitHub issues. To participate
 please visit:
 
-[MCUboot Issues](https://github.com/runtimeco/mcuboot/issues)
+[MCUboot Issues](https://github.com/JuulLabs-OSS/mcuboot/issues)
 
 ~~Issues were previously tracked on [MCUboot JIRA](https://runtimeco.atlassian.net/projects/MCUB/summary)
 , but it is now deprecated.~~
@@ -52,12 +52,12 @@ Information and documentation on the bootloader is stored within the source.
 
 For more information in the source, here are some pointers:
 
-- [boot/bootutil](https://github.com/runtimeco/mcuboot/tree/master/boot/bootutil): The core of the bootloader itself.
-- [boot/boot\_serial](https://github.com/runtimeco/mcuboot/tree/master/boot/boot_serial): Support for serial upgrade within the bootloader itself.
-- [boot/zephyr](https://github.com/runtimeco/mcuboot/tree/master/boot/zephyr): Port of the bootloader to Zephyr
-- [boot/mynewt](https://github.com/runtimeco/mcuboot/tree/master/boot/mynewt): Mynewt bootloader app
-- [imgtool](https://github.com/runtimeco/mcuboot/tree/master/scripts/imgtool.py): A tool to securely sign firmware images for booting by MCUboot.
-- [sim](https://github.com/runtimeco/mcuboot/tree/master/sim): A bootloader simulator for testing and regression
+- [boot/bootutil](https://github.com/JuulLabs-OSS/mcuboot/tree/master/boot/bootutil): The core of the bootloader itself.
+- [boot/boot\_serial](https://github.com/JuulLabs-OSS/mcuboot/tree/master/boot/boot_serial): Support for serial upgrade within the bootloader itself.
+- [boot/zephyr](https://github.com/JuulLabs-OSS/mcuboot/tree/master/boot/zephyr): Port of the bootloader to Zephyr
+- [boot/mynewt](https://github.com/JuulLabs-OSS/mcuboot/tree/master/boot/mynewt): Mynewt bootloader app
+- [imgtool](https://github.com/JuulLabs-OSS/mcuboot/tree/master/scripts/imgtool.py): A tool to securely sign firmware images for booting by MCUboot.
+- [sim](https://github.com/JuulLabs-OSS/mcuboot/tree/master/sim): A bootloader simulator for testing and regression
 
 ## Joining
 

--- a/docs/readme-mynewt.md
+++ b/docs/readme-mynewt.md
@@ -14,7 +14,7 @@ First you need to add the repo to your `project.yml`:
     repository.mcuboot:
         type: github
         vers: 0-dev
-        user: runtimeco
+        user: JuulLabs-OSS
         repo: mcuboot
 ```
 

--- a/testplan/mynewt/project.yml
+++ b/testplan/mynewt/project.yml
@@ -32,5 +32,5 @@ repository.apache-mynewt-core:
 repository.mcuboot:
     type: github
     vers: 0-dev
-    user: runtimeco
+    user: JuulLabs-OSS
     repo: mcuboot


### PR DESCRIPTION
This updates all references from `github.com/runtimeco` to `github.com/JuulLabs-OSS` in docs and yml files.