### PR TITLE
Fix image creation without sign/encryption

### DIFF
--- a/scripts/imgtool.py
+++ b/scripts/imgtool.py
@@ -149,8 +149,7 @@ def sign(key, align, version, header_size, pad_header, slot_size, pad,
             raise Exception("Encryption only available with RSA")
         if key and not isinstance(key, (keys.RSA2048, keys.RSA2048Public)):
             raise Exception("Encryption with sign only available with RSA")
-    if key or enckey:
-        img.create(key, enckey)
+    img.create(key, enckey)
 
     if pad:
         img.pad_to(slot_size)

--- a/scripts/imgtool/image.py
+++ b/scripts/imgtool/image.py
@@ -148,7 +148,7 @@ class Image():
                 raise Exception(msg)
 
     def create(self, key, enckey):
-        self.add_header(key, enckey)
+        self.add_header(enckey)
 
         tlv = TLV(self.endian)
 
@@ -189,11 +189,8 @@ class Image():
 
         self.payload += tlv.get()
 
-    def add_header(self, key, enckey):
-        """Install the image header.
-
-        The key is needed to know the type of signature, and
-        approximate the size of the signature."""
+    def add_header(self, enckey):
+        """Install the image header."""
 
         flags = 0
         if enckey is not None:


### PR DESCRIPTION
Generating images with no signature or encryption was broken by commit 06b77b835336d80c102e35f7c6da997d9380c9b8

This allows generating images with just sha256 again, and fixes a few leftovers from the imghash TLV change.