### PR TITLE
Introduce multi-image boot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
     # separated by ',' and each list of values is run sequentially in the
     # defined order.
     - os: linux
-      env: MULTI_FEATURES="sig-rsa overwrite-only,sig-ecdsa overwrite-only" TEST=sim
+      env: MULTI_FEATURES="sig-rsa overwrite-only,sig-ecdsa overwrite-only,multiimage overwrite-only" TEST=sim
     - os: linux
       env: MULTI_FEATURES="sig-rsa validate-primary-slot,sig-ecdsa validate-primary-slot" TEST=sim
     - os: linux

--- a/NOTICE
+++ b/NOTICE
@@ -6,3 +6,6 @@ The Apache Software Foundation (http://www.apache.org/).
 
 Portions of this software were developed at
 Runtime Inc, copyright 2015.
+
+Portions of this software were developed at
+Arm Limited, copyright 2019.

--- a/boot/bootutil/include/bootutil/enc_key.h
+++ b/boot/bootutil/include/bootutil/enc_key.h
@@ -53,6 +53,7 @@ int boot_enc_set_key(uint8_t slot, uint8_t *enckey);
 int boot_enc_load(const struct image_header *hdr, const struct flash_area *fap,
         uint8_t *enckey);
 bool boot_enc_valid(const struct flash_area *fap);
+void boot_enc_mark_keys_invalid(void);
 void boot_encrypt(const struct flash_area *fap, uint32_t off, uint32_t sz,
         uint32_t blk_off, uint8_t *buf);
 void boot_enc_zeroize(void);

--- a/boot/bootutil/include/bootutil/image.h
+++ b/boot/bootutil/include/bootutil/image.h
@@ -17,6 +17,10 @@
  * under the License.
  */
 
+/*
+ * Modifications are Copyright (c) 2019 Arm Limited.
+ */
+
 #ifndef H_IMAGE_
 #define H_IMAGE_
 
@@ -76,6 +80,7 @@ struct flash_area;
 #define IMAGE_TLV_ED25519           0x24   /* ed25519 of hash output */
 #define IMAGE_TLV_ENC_RSA2048       0x30   /* Key encrypted with RSA-OAEP-2048 */
 #define IMAGE_TLV_ENC_KW128         0x31   /* Key encrypted with AES-KW-128 */
+#define IMAGE_TLV_DEPENDENCY        0x40   /* Image depends on other image */
 
 struct image_version {
     uint8_t iv_major;
@@ -84,16 +89,24 @@ struct image_version {
     uint32_t iv_build_num;
 };
 
+struct image_dependency {
+    uint8_t image_id;                       /* Image index (from 0) */
+    struct image_version image_min_version; /* Indicates at minimum which
+                                             * version of firmware must be
+                                             * available to satisfy compliance
+                                             */
+};
+
 /** Image header.  All fields are in little endian byte order. */
 struct image_header {
     uint32_t ih_magic;
     uint32_t ih_load_addr;
-    uint16_t ih_hdr_size; /* Size of image header (bytes). */
-    uint16_t _pad1;
-    uint32_t ih_img_size; /* Does not include header. */
-    uint32_t ih_flags;    /* IMAGE_F_[...]. */
+    uint16_t ih_hdr_size;           /* Size of image header (bytes). */
+    uint16_t ih_protect_tlv_size;   /* Size of protected TLV area (bytes). */
+    uint32_t ih_img_size;           /* Does not include header. */
+    uint32_t ih_flags;              /* IMAGE_F_[...]. */
     struct image_version ih_ver;
-    uint32_t _pad2;
+    uint32_t _pad1;
 };
 
 /** Image TLV header.  All fields in little endian. */

--- a/boot/bootutil/src/bootutil_misc.c
+++ b/boot/bootutil/src/bootutil_misc.c
@@ -172,13 +172,12 @@ boot_magic_off(const struct flash_area *fap)
 int
 boot_status_entries(const struct flash_area *fap)
 {
-    switch (fap->fa_id) {
-    case FLASH_AREA_IMAGE_PRIMARY:
-    case FLASH_AREA_IMAGE_SECONDARY:
-        return BOOT_STATUS_STATE_COUNT * BOOT_STATUS_MAX_ENTRIES;
-    case FLASH_AREA_IMAGE_SCRATCH:
+    if (fap->fa_id == FLASH_AREA_IMAGE_SCRATCH) {
         return BOOT_STATUS_STATE_COUNT;
-    default:
+    } else if ((fap->fa_id == FLASH_AREA_IMAGE_PRIMARY) ||
+               (fap->fa_id == FLASH_AREA_IMAGE_SECONDARY)) {
+        return BOOT_STATUS_STATE_COUNT * BOOT_STATUS_MAX_ENTRIES;
+    } else {
         return BOOT_EBADARGS;
     }
 }
@@ -301,16 +300,14 @@ boot_read_swap_state_by_id(int flash_area_id, struct boot_swap_state *state)
     const struct flash_area *fap;
     int rc;
 
-    switch (flash_area_id) {
-    case FLASH_AREA_IMAGE_SCRATCH:
-    case FLASH_AREA_IMAGE_PRIMARY:
-    case FLASH_AREA_IMAGE_SECONDARY:
+    if (flash_area_id == FLASH_AREA_IMAGE_SCRATCH ||
+        flash_area_id == FLASH_AREA_IMAGE_PRIMARY ||
+        flash_area_id == FLASH_AREA_IMAGE_SECONDARY) {
         rc = flash_area_open(flash_area_id, &fap);
         if (rc != 0) {
             return BOOT_EFLASH;
         }
-        break;
-    default:
+    } else {
         return BOOT_EBADARGS;
     }
 

--- a/boot/bootutil/src/bootutil_misc.c
+++ b/boot/bootutil/src/bootutil_misc.c
@@ -741,3 +741,38 @@ done:
     flash_area_close(fap);
     return rc;
 }
+
+#if (BOOT_IMAGE_NUMBER > 1)
+/**
+ * Check if the version of the image is not older than required.
+ *
+ * @param req         Required minimal image version.
+ * @param ver         Version of the image to be checked.
+ *
+ * @return            0 if the version is sufficient, nonzero otherwise.
+ */
+int
+boot_is_version_sufficient(struct image_version *req,
+                           struct image_version *ver)
+{
+    if (ver->iv_major > req->iv_major) {
+        return 0;
+    }
+    if (ver->iv_major < req->iv_major) {
+        return BOOT_EBADVERSION;
+    }
+    /* The major version numbers are equal. */
+    if (ver->iv_minor > req->iv_minor) {
+        return 0;
+    }
+    if (ver->iv_minor < req->iv_minor) {
+        return BOOT_EBADVERSION;
+    }
+    /* The minor version numbers are equal. */
+    if (ver->iv_revision < req->iv_revision) {
+        return BOOT_EBADVERSION;
+    }
+
+    return 0;
+}
+#endif /* BOOT_IMAGE_NUMBER > 1 */

--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -48,13 +48,14 @@ extern "C" {
 
 struct flash_area;
 
-#define BOOT_EFLASH     1
-#define BOOT_EFILE      2
-#define BOOT_EBADIMAGE  3
-#define BOOT_EBADVECT   4
-#define BOOT_EBADSTATUS 5
-#define BOOT_ENOMEM     6
-#define BOOT_EBADARGS   7
+#define BOOT_EFLASH      1
+#define BOOT_EFILE       2
+#define BOOT_EBADIMAGE   3
+#define BOOT_EBADVECT    4
+#define BOOT_EBADSTATUS  5
+#define BOOT_ENOMEM      6
+#define BOOT_EBADARGS    7
+#define BOOT_EBADVERSION 8
 
 #define BOOT_TMPBUF_SZ  256
 
@@ -240,6 +241,10 @@ int boot_read_swap_size(uint32_t *swap_size);
 int boot_write_enc_key(const struct flash_area *fap, uint8_t slot,
                        const uint8_t *enckey);
 int boot_read_enc_key(uint8_t slot, uint8_t *enckey);
+#endif
+#if (BOOT_IMAGE_NUMBER > 1)
+int boot_is_version_sufficient(struct image_version *req,
+                               struct image_version *ver);
 #endif
 
 /*

--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -134,6 +134,12 @@ struct boot_swap_state {
     uint8_t image_num;  /* Boot status belongs to this image */
 };
 
+#ifdef MCUBOOT_IMAGE_NUMBER
+#define BOOT_IMAGE_NUMBER          MCUBOOT_IMAGE_NUMBER
+#else
+#define BOOT_IMAGE_NUMBER          1
+#endif
+
 #define BOOT_MAX_IMG_SECTORS       MCUBOOT_MAX_IMG_SECTORS
 
 /*
@@ -302,23 +308,21 @@ boot_initialize_area(struct boot_loader_state *state, int flash_area)
     int num_sectors = BOOT_MAX_IMG_SECTORS;
     int rc;
 
-    switch (flash_area) {
-    case FLASH_AREA_IMAGE_PRIMARY:
+    if (flash_area == FLASH_AREA_IMAGE_PRIMARY) {
         rc = flash_area_to_sectors(flash_area, &num_sectors,
                                    state->imgs[BOOT_PRIMARY_SLOT].sectors);
         state->imgs[BOOT_PRIMARY_SLOT].num_sectors = (size_t)num_sectors;
-        break;
-    case FLASH_AREA_IMAGE_SECONDARY:
+
+    } else if (flash_area == FLASH_AREA_IMAGE_SECONDARY) {
         rc = flash_area_to_sectors(flash_area, &num_sectors,
                                    state->imgs[BOOT_SECONDARY_SLOT].sectors);
         state->imgs[BOOT_SECONDARY_SLOT].num_sectors = (size_t)num_sectors;
-        break;
-    case FLASH_AREA_IMAGE_SCRATCH:
+
+    } else if (flash_area == FLASH_AREA_IMAGE_SCRATCH) {
         rc = flash_area_to_sectors(flash_area, &num_sectors,
                                    state->scratch.sectors);
         state->scratch.num_sectors = (size_t)num_sectors;
-        break;
-    default:
+    } else {
         return BOOT_EFLASH;
     }
 
@@ -350,24 +354,19 @@ boot_initialize_area(struct boot_loader_state *state, int flash_area)
     size_t *out_num_sectors;
     int rc;
 
-    switch (flash_area) {
-    case FLASH_AREA_IMAGE_PRIMARY:
-        num_sectors = BOOT_MAX_IMG_SECTORS;
+    num_sectors = BOOT_MAX_IMG_SECTORS;
+
+    if (flash_area == FLASH_AREA_IMAGE_PRIMARY) {
         out_sectors = state->imgs[BOOT_PRIMARY_SLOT].sectors;
         out_num_sectors = &state->imgs[BOOT_PRIMARY_SLOT].num_sectors;
-        break;
-    case FLASH_AREA_IMAGE_SECONDARY:
-        num_sectors = BOOT_MAX_IMG_SECTORS;
+    } else if (flash_area == FLASH_AREA_IMAGE_SECONDARY) {
         out_sectors = state->imgs[BOOT_SECONDARY_SLOT].sectors;
         out_num_sectors = &state->imgs[BOOT_SECONDARY_SLOT].num_sectors;
-        break;
-    case FLASH_AREA_IMAGE_SCRATCH:
-        num_sectors = BOOT_MAX_IMG_SECTORS;
+    } else if (flash_area == FLASH_AREA_IMAGE_SCRATCH) {
         out_sectors = state->scratch.sectors;
         out_num_sectors = &state->scratch.num_sectors;
-        break;
-    default:
-        return -1;
+    } else {
+        return BOOT_EFLASH;
     }
 
     rc = flash_area_get_sectors(flash_area, &num_sectors, out_sectors);

--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -124,6 +124,7 @@ struct boot_status {
  *      (`MCUBOOT_ENC_IMAGES`).
  */
 
+extern uint8_t current_image;
 extern const uint32_t boot_img_magic[4];
 
 struct boot_swap_state {
@@ -202,7 +203,7 @@ struct boot_loader_state {
         const struct flash_area *area;
         boot_sector_t *sectors;
         size_t num_sectors;
-    } imgs[BOOT_NUM_SLOTS];
+    } imgs[BOOT_IMAGE_NUMBER][BOOT_NUM_SLOTS];
 
     struct {
         const struct flash_area *area;
@@ -210,6 +211,7 @@ struct boot_loader_state {
         size_t num_sectors;
     } scratch;
 
+    uint8_t swap_type[BOOT_IMAGE_NUMBER];
     uint8_t write_sz;
 };
 
@@ -245,20 +247,22 @@ int boot_read_enc_key(uint8_t slot, uint8_t *enckey);
  */
 
 /* These are macros so they can be used as lvalues. */
-#define BOOT_IMG_AREA(state, slot) ((state)->imgs[(slot)].area)
+#define BOOT_IMG(state, slot) ((state)->imgs[current_image][(slot)])
+#define BOOT_IMG_AREA(state, slot) (BOOT_IMG(state, slot).area)
 #define BOOT_SCRATCH_AREA(state) ((state)->scratch.area)
 #define BOOT_WRITE_SZ(state) ((state)->write_sz)
+#define BOOT_SWAP_TYPE(state) ((state)->swap_type[current_image])
 
 static inline struct image_header*
 boot_img_hdr(struct boot_loader_state *state, size_t slot)
 {
-    return &state->imgs[slot].hdr;
+    return &BOOT_IMG(state, slot).hdr;
 }
 
 static inline size_t
 boot_img_num_sectors(struct boot_loader_state *state, size_t slot)
 {
-    return state->imgs[slot].num_sectors;
+    return BOOT_IMG(state, slot).num_sectors;
 }
 
 static inline size_t
@@ -273,7 +277,7 @@ boot_scratch_num_sectors(struct boot_loader_state *state)
 static inline uint32_t
 boot_img_slot_off(struct boot_loader_state *state, size_t slot)
 {
-    return state->imgs[slot].area->fa_off;
+    return BOOT_IMG(state, slot).area->fa_off;
 }
 
 static inline size_t boot_scratch_area_size(struct boot_loader_state *state)
@@ -287,7 +291,7 @@ static inline size_t
 boot_img_sector_size(struct boot_loader_state *state,
                      size_t slot, size_t sector)
 {
-    return state->imgs[slot].sectors[sector].fa_size;
+    return BOOT_IMG(state, slot).sectors[sector].fa_size;
 }
 
 /*
@@ -298,8 +302,8 @@ static inline uint32_t
 boot_img_sector_off(struct boot_loader_state *state, size_t slot,
                     size_t sector)
 {
-    return state->imgs[slot].sectors[sector].fa_off -
-           state->imgs[slot].sectors[0].fa_off;
+    return BOOT_IMG(state, slot).sectors[sector].fa_off -
+           BOOT_IMG(state, slot).sectors[0].fa_off;
 }
 
 static inline int
@@ -310,13 +314,13 @@ boot_initialize_area(struct boot_loader_state *state, int flash_area)
 
     if (flash_area == FLASH_AREA_IMAGE_PRIMARY) {
         rc = flash_area_to_sectors(flash_area, &num_sectors,
-                                   state->imgs[BOOT_PRIMARY_SLOT].sectors);
-        state->imgs[BOOT_PRIMARY_SLOT].num_sectors = (size_t)num_sectors;
+                                   BOOT_IMG(state, BOOT_PRIMARY_SLOT).sectors);
+        BOOT_IMG(state, BOOT_PRIMARY_SLOT).num_sectors = (size_t)num_sectors;
 
     } else if (flash_area == FLASH_AREA_IMAGE_SECONDARY) {
         rc = flash_area_to_sectors(flash_area, &num_sectors,
-                                   state->imgs[BOOT_SECONDARY_SLOT].sectors);
-        state->imgs[BOOT_SECONDARY_SLOT].num_sectors = (size_t)num_sectors;
+                                 BOOT_IMG(state, BOOT_SECONDARY_SLOT).sectors);
+        BOOT_IMG(state, BOOT_SECONDARY_SLOT).num_sectors = (size_t)num_sectors;
 
     } else if (flash_area == FLASH_AREA_IMAGE_SCRATCH) {
         rc = flash_area_to_sectors(flash_area, &num_sectors,
@@ -335,15 +339,15 @@ static inline size_t
 boot_img_sector_size(struct boot_loader_state *state,
                      size_t slot, size_t sector)
 {
-    return state->imgs[slot].sectors[sector].fs_size;
+    return BOOT_IMG(state, slot).sectors[sector].fs_size;
 }
 
 static inline uint32_t
 boot_img_sector_off(struct boot_loader_state *state, size_t slot,
                     size_t sector)
 {
-    return state->imgs[slot].sectors[sector].fs_off -
-           state->imgs[slot].sectors[0].fs_off;
+    return BOOT_IMG(state, slot).sectors[sector].fs_off -
+           BOOT_IMG(state, slot).sectors[0].fs_off;
 }
 
 static inline int
@@ -357,11 +361,11 @@ boot_initialize_area(struct boot_loader_state *state, int flash_area)
     num_sectors = BOOT_MAX_IMG_SECTORS;
 
     if (flash_area == FLASH_AREA_IMAGE_PRIMARY) {
-        out_sectors = state->imgs[BOOT_PRIMARY_SLOT].sectors;
-        out_num_sectors = &state->imgs[BOOT_PRIMARY_SLOT].num_sectors;
+        out_sectors = BOOT_IMG(state, BOOT_PRIMARY_SLOT).sectors;
+        out_num_sectors = &BOOT_IMG(state, BOOT_PRIMARY_SLOT).num_sectors;
     } else if (flash_area == FLASH_AREA_IMAGE_SECONDARY) {
-        out_sectors = state->imgs[BOOT_SECONDARY_SLOT].sectors;
-        out_num_sectors = &state->imgs[BOOT_SECONDARY_SLOT].num_sectors;
+        out_sectors = BOOT_IMG(state, BOOT_SECONDARY_SLOT).sectors;
+        out_num_sectors = &BOOT_IMG(state, BOOT_SECONDARY_SLOT).num_sectors;
     } else if (flash_area == FLASH_AREA_IMAGE_SCRATCH) {
         out_sectors = state->scratch.sectors;
         out_num_sectors = &state->scratch.num_sectors;

--- a/boot/bootutil/src/encrypted.c
+++ b/boot/bootutil/src/encrypted.c
@@ -322,6 +322,16 @@ boot_enc_valid(const struct flash_area *fap)
 }
 
 void
+boot_enc_mark_keys_invalid(void)
+{
+    size_t slot;
+
+    for(slot = 0; slot < BOOT_NUM_SLOTS; ++slot) {
+        enc_state[slot].valid = 0;
+    }
+}
+
+void
 boot_encrypt(const struct flash_area *fap, uint32_t off, uint32_t sz,
         uint32_t blk_off, uint8_t *buf)
 {

--- a/boot/bootutil/src/image_validate.c
+++ b/boot/bootutil/src/image_validate.c
@@ -17,6 +17,10 @@
  * under the License.
  */
 
+/*
+ * Modifications are Copyright (c) 2019 Arm Limited.
+ */
+
 #include <assert.h>
 #include <stddef.h>
 #include <inttypes.h>
@@ -78,12 +82,20 @@ bootutil_img_hash(struct image_header *hdr, const struct flash_area *fap,
     }
 #endif
 
-    /*
-     * Hash is computed over image header and image itself. No TLV is
-     * included ATM.
-     */
+    /* Hash is computed over image header and image itself. */
     hdr_size = hdr->ih_hdr_size;
     size = hdr->ih_img_size + hdr_size;
+
+#if (MCUBOOT_IMAGE_NUMBER > 1)
+    /* If dependency TLVs are present then the TLV info header and the
+     * dependency TLVs are also protected and have to be included in the hash
+     * calculation.
+     */
+    if (hdr->ih_protect_tlv_size != 0) {
+        size += hdr->ih_protect_tlv_size;
+    }
+#endif
+
     for (off = 0; off < size; off += blk_sz) {
         blk_sz = size - off;
         if (blk_sz > tmp_buf_sz) {
@@ -212,7 +224,6 @@ bootutil_img_validate(struct image_header *hdr, const struct flash_area *fap,
     }
 
     /* The TLVs come after the image. */
-    /* After image there are TLVs. */
     off = hdr->ih_img_size + hdr->ih_hdr_size;
 
     rc = flash_area_read(fap, off, &info, sizeof(info));

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -1606,6 +1606,198 @@ out:
 }
 #endif /* !MCUBOOT_OVERWRITE_ONLY */
 
+#if (BOOT_IMAGE_NUMBER > 1)
+/**
+ * Check the image dependency whether it is satisfied and modify
+ * the swap type if necessary.
+ *
+ * @param dep               Image dependency which has to be verified.
+ *
+ * @return                  0 on success; nonzero on failure.
+ */
+static int
+boot_verify_single_dependency(struct image_dependency *dep)
+{
+    struct image_version *dep_version;
+    size_t dep_slot;
+    int rc;
+
+    /* Determine the source of the image which is the subject of
+     * the dependency and get it's version. */
+    dep_slot = (boot_data.swap_type[dep->image_id] != BOOT_SWAP_TYPE_NONE) ?
+                BOOT_SECONDARY_SLOT : BOOT_PRIMARY_SLOT;
+    dep_version = &boot_data.imgs[dep->image_id][dep_slot].hdr.ih_ver;
+
+    rc = boot_is_version_sufficient(&dep->image_min_version, dep_version);
+    if (rc != 0) {
+        /* Dependency not satisfied.
+         * Modify the swap type to decrease the version number of the image
+         * (which will be located in the primary slot after the boot process),
+         * consequently the number of unsatisfied dependencies will be
+         * decreased or remain the same.
+         */
+        switch (BOOT_SWAP_TYPE(&boot_data)) {
+        case BOOT_SWAP_TYPE_TEST:
+        case BOOT_SWAP_TYPE_PERM:
+            BOOT_SWAP_TYPE(&boot_data) = BOOT_SWAP_TYPE_NONE;
+            break;
+        case BOOT_SWAP_TYPE_NONE:
+            BOOT_SWAP_TYPE(&boot_data) = BOOT_SWAP_TYPE_REVERT;
+            break;
+        default:
+            break;
+        }
+    }
+
+    return rc;
+}
+
+/**
+ * Read all dependency TLVs of an image from the flash and verify
+ * one after another to see if they are all satisfied.
+ *
+ * @param slot              Image slot number.
+ *
+ * @return                  0 on success; nonzero on failure.
+ */
+static int
+boot_verify_all_dependency(uint32_t slot)
+{
+    const struct flash_area *fap;
+    struct image_header *hdr;
+    struct image_tlv_info info;
+    struct image_tlv tlv;
+    struct image_dependency dep;
+    uint32_t off;
+    uint32_t end;
+    bool dep_tlvs_found = false;
+    int rc;
+
+    rc = flash_area_open(flash_area_id_from_image_slot(slot), &fap);
+    if (rc != 0) {
+        rc = BOOT_EFLASH;
+        goto done;
+    }
+
+    hdr = boot_img_hdr(&boot_data, slot);
+    /* The TLVs come after the image. */
+    off = hdr->ih_hdr_size + hdr->ih_img_size;
+
+    /* The TLV area always starts with an image_tlv_info structure. */
+    rc = flash_area_read(fap, off, &info, sizeof(info));
+    if (rc != 0) {
+        rc = BOOT_EFLASH;
+        goto done;
+    }
+
+    if (info.it_magic != IMAGE_TLV_INFO_MAGIC) {
+        rc = BOOT_EBADIMAGE;
+        goto done;
+    }
+    end = off + info.it_tlv_tot;
+    off += sizeof(info);
+
+    /* Traverse through all of the TLVs to find the dependency TLVs. */
+    for (; off < end; off += sizeof(tlv) + tlv.it_len) {
+        rc = flash_area_read(fap, off, &tlv, sizeof(tlv));
+        if (rc != 0) {
+             rc = BOOT_EFLASH;
+             goto done;
+         }
+
+        if (tlv.it_type == IMAGE_TLV_DEPENDENCY) {
+            if (!dep_tlvs_found) {
+                dep_tlvs_found = true;
+            }
+
+            if (tlv.it_len != sizeof(dep)) {
+                rc = BOOT_EBADIMAGE;
+                goto done;
+            }
+
+            rc = flash_area_read(fap, off + sizeof(tlv), &dep, tlv.it_len);
+            if (rc != 0) {
+                rc = BOOT_EFLASH;
+                goto done;
+            }
+
+            /* Verify dependency and modify the swap type if not satisfied. */
+            rc = boot_verify_single_dependency(&dep);
+            if (rc != 0) {
+                /* Dependency not satisfied. */
+                goto done;
+            }
+
+            /* Dependency satisfied, no action needed.
+             * Continue with the next TLV entry.
+             */
+        } else if (dep_tlvs_found) {
+            /* The dependency TLVs are contiguous in the TLV area. If a
+             * dependency had already been found and the last read TLV
+             * has a different type then there are no more dependency TLVs.
+             * The search can be finished.
+             */
+            break;
+        }
+    }
+
+done:
+    flash_area_close(fap);
+    return rc;
+}
+
+/**
+ * Verify whether the image dependencies in the TLV area are
+ * all satisfied and modify the swap type if necessary.
+ *
+ * @return                  0 if all dependencies are satisfied,
+ *                          nonzero otherwise.
+ */
+static int
+boot_verify_single_image_dependency(void)
+{
+    size_t slot;
+
+    /* Determine the source of the dependency TLVs. Those dependencies have to
+     * be checked which belong to the image that will be located in the primary
+     * slot after the firmware update process.
+     */
+    if (BOOT_SWAP_TYPE(&boot_data) != BOOT_SWAP_TYPE_NONE &&
+        BOOT_SWAP_TYPE(&boot_data) != BOOT_SWAP_TYPE_FAIL) {
+        slot = BOOT_SECONDARY_SLOT;
+    } else {
+        slot = BOOT_PRIMARY_SLOT;
+    }
+
+    return boot_verify_all_dependency(slot);
+}
+
+/**
+ * Iterate over all the images and verify whether the image dependencies in the
+ * TLV area are all satisfied and update the related swap type if necessary.
+ */
+static void
+boot_verify_all_image_dependency(void)
+{
+    current_image = 0;
+    int rc;
+
+    while (current_image < BOOT_IMAGE_NUMBER) {
+        rc = boot_verify_single_image_dependency();
+        if ( rc == 0) {
+            /* All dependencies've been satisfied, continue with next image. */
+            current_image++;
+        } else if (rc == BOOT_EBADVERSION) {
+            /* Dependency check needs to be restarted. */
+            current_image = 0;
+        } else {
+            /* Other error happened, images are inconsistent */
+            return;
+        }
+    }
+}
+#endif /* (BOOT_IMAGE_NUMBER > 1) */
+
 /**
  * Performs a clean (not aborted) image update.
  *
@@ -1963,6 +2155,13 @@ boot_go(struct boot_rsp *rsp)
         /* Determine swap type and complete swap if it has been aborted. */
         boot_prepare_image_for_update(&bs);
     }
+
+#if (BOOT_IMAGE_NUMBER > 1)
+    /* Iterate over all the images and verify whether the image dependencies
+     * are all satisfied and update swap type if necessary.
+     */
+    boot_verify_all_image_dependency();
+#endif
 
     /* Iterate over all the images. At this point there are no aborted swaps
      * and the swap types are determined for each image. By the end of the loop

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -47,6 +47,7 @@
 MCUBOOT_LOG_MODULE_DECLARE(mcuboot);
 
 static struct boot_loader_state boot_data;
+uint8_t current_image = 0;
 
 #if defined(MCUBOOT_VALIDATE_PRIMARY_SLOT) && !defined(MCUBOOT_OVERWRITE_ONLY)
 static int boot_status_fails = 0;
@@ -1019,18 +1020,20 @@ boot_erase_trailer_sectors(const struct flash_area *fap)
     uint32_t total_sz;
     uint32_t off;
     uint32_t sz;
+    int fa_id_primary;
+    int fa_id_secondary;
     int rc;
 
     BOOT_LOG_DBG("erasing trailer; fa_id=%d", fap->fa_id);
 
-    switch (fap->fa_id) {
-    case FLASH_AREA_IMAGE_PRIMARY:
+    fa_id_primary   = flash_area_id_from_image_slot(BOOT_PRIMARY_SLOT);
+    fa_id_secondary = flash_area_id_from_image_slot(BOOT_SECONDARY_SLOT);
+
+    if (fap->fa_id == fa_id_primary) {
         slot = BOOT_PRIMARY_SLOT;
-        break;
-    case FLASH_AREA_IMAGE_SECONDARY:
+    } else if (fap->fa_id == fa_id_secondary) {
         slot = BOOT_SECONDARY_SLOT;
-        break;
-    default:
+    } else {
         return BOOT_EFLASH;
     }
 

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -190,6 +190,18 @@ boot_status_source(void)
              table->bst_copy_done_primary_slot == state_primary_slot.copy_done))
         {
             source = table->bst_status_source;
+
+#if (BOOT_IMAGE_NUMBER > 1)
+            /* In case of multi-image boot it can happen that if boot status
+             * info is found on scratch area then it does not belong to the
+             * currently examined image.
+             */
+            if (source == BOOT_STATUS_SOURCE_SCRATCH &&
+                state_scratch.image_num != current_image) {
+                source = BOOT_STATUS_SOURCE_NONE;
+            }
+#endif
+
             BOOT_LOG_INF("Boot source: %s",
                          source == BOOT_STATUS_SOURCE_NONE ? "none" :
                          source == BOOT_STATUS_SOURCE_SCRATCH ? "scratch" :
@@ -305,8 +317,8 @@ boot_write_sz(void)
      * on what the minimum write size is for scratch area, active image slot.
      * We need to use the bigger of those 2 values.
      */
-    elem_sz = flash_area_align(boot_data.imgs[BOOT_PRIMARY_SLOT].area);
-    align = flash_area_align(boot_data.scratch.area);
+    elem_sz = flash_area_align(BOOT_IMG_AREA(&boot_data, BOOT_PRIMARY_SLOT));
+    align = flash_area_align(BOOT_SCRATCH_AREA(&boot_data));
     if (align > elem_sz) {
         elem_sz = align;
     }
@@ -982,7 +994,7 @@ boot_status_init(const struct flash_area *fap, const struct boot_status *bs)
     if (bs->swap_type != BOOT_SWAP_TYPE_NONE) {
         rc = boot_write_swap_info(fap,
                                   bs->swap_type,
-                                  0);
+                                  current_image);
         assert(rc == 0);
     }
 
@@ -1098,8 +1110,8 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_status *bs)
      * controls if special handling is needed (swapping last sector).
      */
     last_sector = boot_img_num_sectors(&boot_data, BOOT_PRIMARY_SLOT) - 1;
-    if (img_off + sz > boot_img_sector_off(&boot_data, BOOT_PRIMARY_SLOT,
-                                           last_sector)) {
+    if ((img_off + sz) >
+        boot_img_sector_off(&boot_data, BOOT_PRIMARY_SLOT, last_sector)) {
         copy_sz -= trailer_sz;
     }
 
@@ -1206,7 +1218,7 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_status *bs)
             if (swap_state.swap_type != BOOT_SWAP_TYPE_NONE) {
                 rc = boot_write_swap_info(fap_primary_slot,
                                           swap_state.swap_type,
-                                          0);
+                                          current_image);
                 assert(rc == 0);
             }
 
@@ -1595,83 +1607,292 @@ out:
 #endif /* !MCUBOOT_OVERWRITE_ONLY */
 
 /**
- * Performs an image swap if one is required.
+ * Performs a clean (not aborted) image update.
  *
- * @param out_swap_type         On success, the type of swap performed gets
- *                                  written here.
+ * @param bs                    The current boot status.
  *
  * @return                      0 on success; nonzero on failure.
  */
 static int
-boot_swap_if_needed(int *out_swap_type)
+boot_perform_update(struct boot_status *bs)
 {
-    struct boot_status bs;
     int rc;
 
-    /* Determine if we rebooted in the middle of an image swap operation. */
-    rc = boot_read_status(&bs);
+    /* At this point there are no aborted swaps. */
+#if defined(MCUBOOT_OVERWRITE_ONLY)
+    rc = boot_copy_image(bs);
+#elif defined(MCUBOOT_BOOTSTRAP)
+    /* Check if the image update was triggered by a bad image in the
+     * primary slot (the validity of the image in the secondary slot had
+     * already been checked).
+     */
+    if (boot_check_header_erased(BOOT_PRIMARY_SLOT) == 0 ||
+        boot_validate_slot(BOOT_PRIMARY_SLOT, bs) != 0) {
+        rc = boot_copy_image(bs);
+    } else {
+        rc = boot_swap_image(bs);
+    }
+#else
+        rc = boot_swap_image(bs);
+#endif
     assert(rc == 0);
-    if (rc != 0) {
-        return rc;
+
+#ifndef MCUBOOT_OVERWRITE_ONLY
+    /* The following state needs image_ok be explicitly set after the
+     * swap was finished to avoid a new revert.
+     */
+    if (BOOT_SWAP_TYPE(&boot_data) == BOOT_SWAP_TYPE_REVERT ||
+        BOOT_SWAP_TYPE(&boot_data) == BOOT_SWAP_TYPE_PERM) {
+        rc = boot_set_image_ok();
+        if (rc != 0) {
+            BOOT_SWAP_TYPE(&boot_data) = BOOT_SWAP_TYPE_PANIC;
+        }
     }
 
-    /* If a partial swap was detected, complete it. */
-    if (bs.idx != BOOT_STATUS_IDX_0 || bs.state != BOOT_STATUS_STATE_0) {
-#ifdef MCUBOOT_OVERWRITE_ONLY
-        /* Should never arrive here, overwrite-only mode has no swap state. */
-        assert(0);
-#else
-        /* Determine the type of swap operation being resumed from the
-         * `swap-type` trailer field.
-         */
-        rc = boot_swap_image(&bs);
-        assert(rc == 0);
-#endif
-
-    } else {
-        if (bs.swap_type == BOOT_SWAP_TYPE_NONE) {
-            bs.swap_type = boot_validated_swap_type(&bs);
-        } else if (boot_validate_slot(BOOT_SECONDARY_SLOT, &bs) != 0) {
-            bs.swap_type = BOOT_SWAP_TYPE_FAIL;
+    if (BOOT_SWAP_TYPE(&boot_data) == BOOT_SWAP_TYPE_TEST ||
+        BOOT_SWAP_TYPE(&boot_data) == BOOT_SWAP_TYPE_PERM ||
+        BOOT_SWAP_TYPE(&boot_data) == BOOT_SWAP_TYPE_REVERT) {
+        rc = boot_set_copy_done();
+        if (rc != 0) {
+            BOOT_SWAP_TYPE(&boot_data) = BOOT_SWAP_TYPE_PANIC;
         }
-        switch (bs.swap_type) {
-        case BOOT_SWAP_TYPE_TEST:
-        case BOOT_SWAP_TYPE_PERM:
-        case BOOT_SWAP_TYPE_REVERT:
-#ifdef MCUBOOT_OVERWRITE_ONLY
-            rc = boot_copy_image(&bs);
-#else
-            rc = boot_swap_image(&bs);
-#endif
-            assert(rc == 0);
-            break;
-#ifdef MCUBOOT_BOOTSTRAP
-        case BOOT_SWAP_TYPE_NONE:
-            /*
-             * Header checks are done first because they are inexpensive.
-             * Since overwrite-only copies starting from offset 0, if
-             * interrupted, it might leave a valid header magic, so also
-             * run validation on the primary slot to be sure it's not OK.
-             */
-            if (boot_check_header_erased(BOOT_PRIMARY_SLOT) == 0 ||
-                boot_validate_slot(BOOT_PRIMARY_SLOT, &bs) != 0) {
-                if ((boot_img_hdr(&boot_data, BOOT_SECONDARY_SLOT)->ih_magic
-                     == IMAGE_MAGIC ) &&
-                    (boot_validate_slot(BOOT_SECONDARY_SLOT, &bs) == 0)) {
-                    rc = boot_copy_image(&bs);
-                    assert(rc == 0);
+    }
+#endif /* !MCUBOOT_OVERWRITE_ONLY */
 
-                    /* Returns fail here to trigger a re-read of the headers. */
-                    bs.swap_type = BOOT_SWAP_TYPE_FAIL;
+    return rc;
+}
+
+/**
+ * Completes a previously aborted image swap.
+ *
+ * @param bs                    The current boot status.
+ *
+ * @return                      0 on success; nonzero on failure.
+ */
+#if !defined(MCUBOOT_OVERWRITE_ONLY)
+static int
+boot_complete_partial_swap(struct boot_status *bs)
+{
+    int rc;
+
+    /* Determine the type of swap operation being resumed from the
+     * `swap-type` trailer field.
+     */
+    rc = boot_swap_image(bs);
+    assert(rc == 0);
+
+    BOOT_SWAP_TYPE(&boot_data) = bs->swap_type;
+
+    /* The following states need image_ok be explicitly set after the
+     * swap was finished to avoid a new revert.
+     */
+    if (bs->swap_type == BOOT_SWAP_TYPE_REVERT ||
+        bs->swap_type == BOOT_SWAP_TYPE_PERM) {
+        rc = boot_set_image_ok();
+        if (rc != 0) {
+            BOOT_SWAP_TYPE(&boot_data) = BOOT_SWAP_TYPE_PANIC;
+        }
+    }
+
+    if (bs->swap_type == BOOT_SWAP_TYPE_TEST ||
+        bs->swap_type == BOOT_SWAP_TYPE_PERM ||
+        bs->swap_type == BOOT_SWAP_TYPE_REVERT) {
+        rc = boot_set_copy_done();
+        if (rc != 0) {
+            BOOT_SWAP_TYPE(&boot_data) = BOOT_SWAP_TYPE_PANIC;
+        }
+    }
+
+    if (BOOT_SWAP_TYPE(&boot_data) == BOOT_SWAP_TYPE_PANIC) {
+        BOOT_LOG_ERR("panic!");
+        assert(0);
+
+        /* Loop forever... */
+        while (1) {}
+    }
+
+    return rc;
+}
+#endif /* !MCUBOOT_OVERWRITE_ONLY */
+
+#if (BOOT_IMAGE_NUMBER > 1)
+/**
+ * Review the validity of previously determined swap types of other images.
+ *
+ * @param aborted_swap          The current image upgrade is a
+ *                              partial/aborted swap.
+ */
+static void
+boot_review_image_swap_types(bool aborted_swap)
+{
+    /* In that case if we rebooted in the middle of an image upgrade process, we
+     * must review the validity of swap types, that were previously determined
+     * for other images. The image_ok flag had not been set before the reboot
+     * for any of the updated images (only the copy_done flag) and thus falsely
+     * the REVERT swap type has been determined for the previous images that had
+     * been updated before the reboot.
+     *
+     * There are two separate scenarios that we have to deal with:
+     *
+     * 1. The reboot has happened during swapping an image:
+     *      The current image upgrade has been determined as a
+     *      partial/aborted swap.
+     * 2. The reboot has happened between two separate image upgrades:
+     *      In this scenario we must check the swap type of the current image.
+     *      In those cases if it is NONE or REVERT we cannot certainly determine
+     *      the fact of a reboot. In a consistent state images must move in the
+     *      same direction or stay in place, e.g. in practice REVERT and TEST
+     *      swap types cannot be present at the same time. If the swap type of
+     *      the current image is either TEST, PERM or FAIL we must review the
+     *      already determined swap types of other images and set each false
+     *      REVERT swap types to NONE (these images had been successfully
+     *      updated before the system rebooted between two separate image
+     *      upgrades).
+     */
+
+    if (current_image == 0) {
+        /* Nothing to do */
+        return;
+    }
+
+    if (!aborted_swap) {
+        if ((BOOT_SWAP_TYPE(&boot_data) == BOOT_SWAP_TYPE_NONE) ||
+            (BOOT_SWAP_TYPE(&boot_data) == BOOT_SWAP_TYPE_REVERT)) {
+            /* Nothing to do */
+            return;
+        }
+    }
+
+    for (uint8_t i = 0; i < current_image; i++) {
+        if (boot_data.swap_type[i] == BOOT_SWAP_TYPE_REVERT) {
+            boot_data.swap_type[i] = BOOT_SWAP_TYPE_NONE;
+        }
+    }
+}
+#endif
+
+/**
+ * Prepare image to be updated if required.
+ *
+ * Prepare image to be updated if required with completing an image swap
+ * operation if one was aborted and/or determining the type of the
+ * swap operation. In case of any error set the swap type to NONE.
+ *
+ * @param bs                    Pointer where the read and possibly updated
+ *                              boot status can be written to.
+ */
+static void
+boot_prepare_image_for_update(struct boot_status *bs)
+{
+    int rc;
+
+    /* Determine the sector layout of the image slots and scratch area. */
+    rc = boot_read_sectors();
+    if (rc != 0) {
+        BOOT_LOG_WRN("Failed reading sectors; BOOT_MAX_IMG_SECTORS=%d"
+                     " - too small?", BOOT_MAX_IMG_SECTORS);
+        /* Unable to determine sector layout, continue with next image
+         * if there is one.
+         */
+        BOOT_SWAP_TYPE(&boot_data) = BOOT_SWAP_TYPE_NONE;
+        return;
+    }
+
+    /* Attempt to read an image header from each slot. */
+    rc = boot_read_image_headers(false);
+    if (rc != 0) {
+        /* Continue with next image if there is one. */
+        BOOT_LOG_WRN("Failed reading image headers; Image=%u", current_image);
+        BOOT_SWAP_TYPE(&boot_data) = BOOT_SWAP_TYPE_NONE;
+        return;
+    }
+
+    /* If the current image's slots aren't compatible, no swap is possible.
+     * Just boot into primary slot.
+     */
+    if (boot_slots_compatible()) {
+
+        rc = boot_read_status(bs);
+        if (rc != 0) {
+            BOOT_LOG_WRN("Failed reading boot status; Image=%u",
+                         current_image);
+            /* Continue with next image if there is one. */
+            BOOT_SWAP_TYPE(&boot_data) = BOOT_SWAP_TYPE_NONE;
+            return;
+        }
+
+        /* Determine if we rebooted in the middle of an image swap
+         * operation. If a partial swap was detected, complete it.
+         */
+        if (bs->idx != BOOT_STATUS_IDX_0 || bs->state != BOOT_STATUS_STATE_0) {
+
+#if (BOOT_IMAGE_NUMBER > 1)
+            boot_review_image_swap_types(true);
+#endif
+
+#ifdef MCUBOOT_OVERWRITE_ONLY
+            /* Should never arrive here, overwrite-only mode has
+             * no swap state.
+             */
+            assert(0);
+#else
+            /* Determine the type of swap operation being resumed from the
+             * `swap-type` trailer field.
+             */
+            rc = boot_complete_partial_swap(bs);
+            assert(rc == 0);
+#endif
+            /* Attempt to read an image header from each slot. Ensure that
+             * image headers in slots are aligned with headers in boot_data.
+             */
+            rc = boot_read_image_headers(false);
+            assert(rc == 0);
+
+            /* Swap has finished set to NONE */
+            BOOT_SWAP_TYPE(&boot_data) = BOOT_SWAP_TYPE_NONE;
+        } else {
+            /* There was no partial swap, determine swap type. */
+            if (bs->swap_type == BOOT_SWAP_TYPE_NONE) {
+                BOOT_SWAP_TYPE(&boot_data) = boot_validated_swap_type(bs);
+            } else if (boot_validate_slot(BOOT_SECONDARY_SLOT, bs) != 0) {
+                BOOT_SWAP_TYPE(&boot_data) = BOOT_SWAP_TYPE_FAIL;
+            } else {
+                BOOT_SWAP_TYPE(&boot_data) = bs->swap_type;
+            }
+
+#if (BOOT_IMAGE_NUMBER > 1)
+            boot_review_image_swap_types(false);
+#endif
+
+#ifdef MCUBOOT_BOOTSTRAP
+            if (BOOT_SWAP_TYPE(&boot_data) == BOOT_SWAP_TYPE_NONE) {
+                /* Header checks are done first because they are
+                 * inexpensive. Since overwrite-only copies starting from
+                 * offset 0, if interrupted, it might leave a valid header
+                 * magic, so also run validation on the primary slot to be
+                 * sure it's not OK.
+                 */
+                 if (boot_check_header_erased(BOOT_PRIMARY_SLOT) == 0 ||
+                     boot_validate_slot(BOOT_PRIMARY_SLOT, bs) != 0) {
+                     if (boot_img_hdr(&boot_data,
+                          BOOT_SECONDARY_SLOT)->ih_magic == IMAGE_MAGIC &&
+                         boot_validate_slot(BOOT_SECONDARY_SLOT, bs) == 0)
+                     {
+                        /* Set swap type to REVERT to overwrite the primary
+                         * slot with the image contained in secondary slot
+                         * and to trigger the explicit setting of the
+                         * image_ok flag.
+                         */
+                         BOOT_SWAP_TYPE(&boot_data) = BOOT_SWAP_TYPE_REVERT;
+                    }
                 }
             }
-            break;
 #endif
         }
+    } else {
+        /* In that case if slots are not compatible. */
+        BOOT_SWAP_TYPE(&boot_data) = BOOT_SWAP_TYPE_NONE;
     }
-
-    *out_swap_type = bs.swap_type;
-    return 0;
 }
 
 /**
@@ -1685,161 +1906,187 @@ boot_swap_if_needed(int *out_swap_type)
 int
 boot_go(struct boot_rsp *rsp)
 {
-    int swap_type;
     size_t slot;
+    struct boot_status bs;
     int rc;
     int fa_id;
-    bool reload_headers = false;
 
     /* The array of slot sectors are defined here (as opposed to file scope) so
      * that they don't get allocated for non-boot-loader apps.  This is
      * necessary because the gcc option "-fdata-sections" doesn't seem to have
      * any effect in older gcc versions (e.g., 4.8.4).
      */
-    static boot_sector_t primary_slot_sectors[BOOT_MAX_IMG_SECTORS];
-    static boot_sector_t secondary_slot_sectors[BOOT_MAX_IMG_SECTORS];
+    static boot_sector_t
+        primary_slot_sectors[BOOT_IMAGE_NUMBER][BOOT_MAX_IMG_SECTORS];
+    static boot_sector_t
+        secondary_slot_sectors[BOOT_IMAGE_NUMBER][BOOT_MAX_IMG_SECTORS];
     static boot_sector_t scratch_sectors[BOOT_MAX_IMG_SECTORS];
-    boot_data.imgs[BOOT_PRIMARY_SLOT].sectors = primary_slot_sectors;
-    boot_data.imgs[BOOT_SECONDARY_SLOT].sectors = secondary_slot_sectors;
-    boot_data.scratch.sectors = scratch_sectors;
 
 #ifdef MCUBOOT_ENC_IMAGES
     /* FIXME: remove this after RAM is cleared by sim */
     boot_enc_zeroize();
 #endif
 
-    /* Open boot_data image areas for the duration of this call. */
-    for (slot = 0; slot < BOOT_NUM_SLOTS; slot++) {
-        fa_id = flash_area_id_from_image_slot(slot);
-        rc = flash_area_open(fa_id, &BOOT_IMG_AREA(&boot_data, slot));
-        assert(rc == 0);
-    }
-    rc = flash_area_open(FLASH_AREA_IMAGE_SCRATCH,
-                         &BOOT_SCRATCH_AREA(&boot_data));
-    assert(rc == 0);
-
-    /* Determine the sector layout of the image slots and scratch area. */
-    rc = boot_read_sectors();
-    if (rc != 0) {
-        BOOT_LOG_WRN("Failed reading sectors; BOOT_MAX_IMG_SECTORS=%d - too small?",
-                BOOT_MAX_IMG_SECTORS);
-        goto out;
-    }
-
-    /* Attempt to read an image header from each slot. */
-    rc = boot_read_image_headers(false);
-    if (rc != 0) {
-        goto out;
-    }
-
-    /* If the image slots aren't compatible, no swap is possible.  Just boot
-     * into the primary slot.
+    /* Iterate over all the images. By the end of the loop the swap type has
+     * to be determined for each image and all aborted swaps have to be
+     * completed.
      */
-    if (boot_slots_compatible()) {
-        rc = boot_swap_if_needed(&swap_type);
-        assert(rc == 0);
-        if (rc != 0) {
-            goto out;
-        }
+    for (current_image = 0; current_image < BOOT_IMAGE_NUMBER; ++current_image)
+    {
 
-        /*
-         * The following states need image_ok be explicitly set after the
-         * swap was finished to avoid a new revert.
+#if defined(MCUBOOT_ENC_IMAGES) && (BOOT_IMAGE_NUMBER > 1)
+        /* The keys used for encryption may no longer be valid (could belong to
+         * another images). Therefore, mark them as invalid to force their reload
+         * by boot_enc_load().
          */
-        if (swap_type == BOOT_SWAP_TYPE_REVERT ||
-            swap_type == BOOT_SWAP_TYPE_FAIL ||
-            swap_type == BOOT_SWAP_TYPE_PERM) {
-#ifndef MCUBOOT_OVERWRITE_ONLY
-            rc = boot_set_image_ok();
-            if (rc != 0) {
-                swap_type = BOOT_SWAP_TYPE_PANIC;
-            }
-#endif /* !MCUBOOT_OVERWRITE_ONLY */
-        }
-    } else {
-        swap_type = BOOT_SWAP_TYPE_NONE;
-    }
-
-    switch (swap_type) {
-    case BOOT_SWAP_TYPE_NONE:
-        slot = BOOT_PRIMARY_SLOT;
-        break;
-
-    case BOOT_SWAP_TYPE_TEST:          /* fallthrough */
-    case BOOT_SWAP_TYPE_PERM:          /* fallthrough */
-    case BOOT_SWAP_TYPE_REVERT:
-        slot = BOOT_SECONDARY_SLOT;
-        reload_headers = true;
-#ifndef MCUBOOT_OVERWRITE_ONLY
-        rc = boot_set_copy_done();
-        if (rc != 0) {
-            swap_type = BOOT_SWAP_TYPE_PANIC;
-        }
-#endif /* !MCUBOOT_OVERWRITE_ONLY */
-        break;
-
-    case BOOT_SWAP_TYPE_FAIL:
-        /* The image in the secondary slot was invalid and is now erased.
-         * Ensure we don't try to boot into it again on the next reboot.
-         * Do this by pretending we just reverted back to the primary slot.
-         */
-        slot = BOOT_PRIMARY_SLOT;
-        reload_headers = true;
-        break;
-
-    default:
-        swap_type = BOOT_SWAP_TYPE_PANIC;
-    }
-
-    if (swap_type == BOOT_SWAP_TYPE_PANIC) {
-        BOOT_LOG_ERR("panic!");
-        assert(0);
-
-        /* Loop forever... */
-        while (1) {}
-    }
-
-    if (reload_headers) {
-        rc = boot_read_image_headers(false);
-        if (rc != 0) {
-            goto out;
-        }
-        /* Since headers were reloaded, it can be assumed we just performed a
-         * swap or overwrite. Now the header info that should be used to
-         * provide the data for the bootstrap, which previously was at the
-         * secondary slot, was updated to the primary slot.
-         */
-        slot = BOOT_PRIMARY_SLOT;
-    }
-
-#ifdef MCUBOOT_VALIDATE_PRIMARY_SLOT
-    rc = boot_validate_slot(BOOT_PRIMARY_SLOT, NULL);
-    if (rc != 0) {
-        rc = BOOT_EBADIMAGE;
-        goto out;
-    }
-#else
-    /* Even if we're not re-validating the primary slot, we could be booting
-     * onto an empty flash chip. At least do a basic sanity check that
-     * the magic number on the image is OK.
-     */
-    if (boot_data.imgs[BOOT_PRIMARY_SLOT].hdr.ih_magic != IMAGE_MAGIC) {
-        BOOT_LOG_ERR("bad image magic 0x%lx",
-                (unsigned long)boot_data.imgs[BOOT_PRIMARY_SLOT].hdr.ih_magic);
-        rc = BOOT_EBADIMAGE;
-        goto out;
-    }
+        boot_enc_mark_keys_invalid();
 #endif
 
-    /* Always boot from the primary slot. */
-    rsp->br_flash_dev_id = boot_data.imgs[BOOT_PRIMARY_SLOT].area->fa_device_id;
-    rsp->br_image_off = boot_img_slot_off(&boot_data, BOOT_PRIMARY_SLOT);
-    rsp->br_hdr = boot_img_hdr(&boot_data, slot);
+        BOOT_IMG(&boot_data, BOOT_PRIMARY_SLOT).sectors =
+                                        primary_slot_sectors[current_image];
+        BOOT_IMG(&boot_data, BOOT_SECONDARY_SLOT).sectors =
+                                        secondary_slot_sectors[current_image];
+        boot_data.scratch.sectors = scratch_sectors;
+
+        /* Open primary and secondary image areas for the duration
+         * of this call.
+         */
+        for (slot = 0; slot < BOOT_NUM_SLOTS; slot++) {
+            fa_id = flash_area_id_from_image_slot(slot);
+            rc = flash_area_open(fa_id, &BOOT_IMG_AREA(&boot_data, slot));
+            assert(rc == 0);
+        }
+        rc = flash_area_open(FLASH_AREA_IMAGE_SCRATCH,
+                             &BOOT_SCRATCH_AREA(&boot_data));
+        assert(rc == 0);
+
+        /* Determine swap type and complete swap if it has been aborted. */
+        boot_prepare_image_for_update(&bs);
+    }
+
+    /* Iterate over all the images. At this point there are no aborted swaps
+     * and the swap types are determined for each image. By the end of the loop
+     * all required update operations will have been finished.
+     */
+    for (current_image = 0; current_image < BOOT_IMAGE_NUMBER; ++current_image)
+    {
+
+#if (BOOT_IMAGE_NUMBER > 1)
+#ifdef MCUBOOT_ENC_IMAGES
+        /* The keys used for encryption may no longer be valid (could belong to
+         * another images). Therefore, mark them as invalid to force their reload
+         * by boot_enc_load().
+         */
+        boot_enc_mark_keys_invalid();
+#endif /* MCUBOOT_ENC_IMAGES */
+
+        /* Indicate that swap is not aborted */
+        memset(&bs, 0, sizeof bs);
+        bs.idx = BOOT_STATUS_IDX_0;
+        bs.state = BOOT_STATUS_STATE_0;
+#endif /* (BOOT_IMAGE_NUMBER > 1) */
+
+        /* Set the previously determined swap type */
+        bs.swap_type = BOOT_SWAP_TYPE(&boot_data);
+
+        switch (BOOT_SWAP_TYPE(&boot_data)) {
+        case BOOT_SWAP_TYPE_NONE:
+            break;
+
+        case BOOT_SWAP_TYPE_TEST:          /* fallthrough */
+        case BOOT_SWAP_TYPE_PERM:          /* fallthrough */
+        case BOOT_SWAP_TYPE_REVERT:
+            rc = boot_perform_update(&bs);
+            assert(rc == 0);
+            break;
+
+        case BOOT_SWAP_TYPE_FAIL:
+            /* The image in secondary slot was invalid and is now erased. Ensure
+             * we don't try to boot into it again on the next reboot. Do this by
+             * pretending we just reverted back to primary slot.
+             */
+#ifndef MCUBOOT_OVERWRITE_ONLY
+            /* image_ok needs to be explicitly set to avoid a new revert. */
+            rc = boot_set_image_ok();
+            if (rc != 0) {
+                BOOT_SWAP_TYPE(&boot_data) = BOOT_SWAP_TYPE_PANIC;
+            }
+#endif /* !MCUBOOT_OVERWRITE_ONLY */
+            break;
+
+        default:
+            BOOT_SWAP_TYPE(&boot_data) = BOOT_SWAP_TYPE_PANIC;
+        }
+
+        if (BOOT_SWAP_TYPE(&boot_data) == BOOT_SWAP_TYPE_PANIC) {
+            BOOT_LOG_ERR("panic!");
+            assert(0);
+
+            /* Loop forever... */
+            while (1) {}
+        }
+    }
+
+    /* Iterate over all the images. At this point all required update operations
+     * have finished. By the end of the loop each image in the primary slot will
+     * have been re-validated.
+     */
+    for (current_image = 0; current_image < BOOT_IMAGE_NUMBER; ++current_image)
+    {
+        if (BOOT_SWAP_TYPE(&boot_data) != BOOT_SWAP_TYPE_NONE) {
+            /* Attempt to read an image header from each slot. Ensure that image
+             * headers in slots are aligned with headers in boot_data.
+             */
+            rc = boot_read_image_headers(false);
+            if (rc != 0) {
+                goto out;
+            }
+            /* Since headers were reloaded, it can be assumed we just performed
+             * a swap or overwrite. Now the header info that should be used to
+             * provide the data for the bootstrap, which previously was at
+             * secondary slot, was updated to primary slot.
+             */
+        }
+
+#ifdef MCUBOOT_VALIDATE_PRIMARY_SLOT
+        rc = boot_validate_slot(BOOT_PRIMARY_SLOT, NULL);
+        if (rc != 0) {
+            rc = BOOT_EBADIMAGE;
+            goto out;
+        }
+#else
+        /* Even if we're not re-validating the primary slot, we could be booting
+         * onto an empty flash chip. At least do a basic sanity check that
+         * the magic number on the image is OK.
+         */
+        if (BOOT_IMG(&boot_data, BOOT_PRIMARY_SLOT).hdr.ih_magic !=
+                IMAGE_MAGIC) {
+            BOOT_LOG_ERR("bad image magic 0x%lx; Image=%u", (unsigned long)
+                         &boot_img_hdr(&boot_data,BOOT_PRIMARY_SLOT)->ih_magic,
+                         current_image);
+            rc = BOOT_EBADIMAGE;
+            goto out;
+        }
+#endif
+    }
+
+    /* Always boot from the primary slot of Image 0. */
+    current_image = 0;
+    rsp->br_flash_dev_id =
+            BOOT_IMG_AREA(&boot_data, BOOT_PRIMARY_SLOT)->fa_device_id;
+    rsp->br_image_off =
+            boot_img_slot_off(&boot_data, BOOT_PRIMARY_SLOT);
+    rsp->br_hdr =
+            boot_img_hdr(&boot_data, BOOT_PRIMARY_SLOT);
 
  out:
-    flash_area_close(BOOT_SCRATCH_AREA(&boot_data));
-    for (slot = 0; slot < BOOT_NUM_SLOTS; slot++) {
-        flash_area_close(BOOT_IMG_AREA(&boot_data, BOOT_NUM_SLOTS - 1 - slot));
+    for (current_image = 0; current_image < BOOT_IMAGE_NUMBER; ++current_image)
+    {
+        flash_area_close(BOOT_SCRATCH_AREA(&boot_data));
+        for (slot = 0; slot < BOOT_NUM_SLOTS; slot++) {
+            flash_area_close(BOOT_IMG_AREA(&boot_data,
+                                           BOOT_NUM_SLOTS - 1 - slot));
+        }
     }
     return rc;
 }
@@ -1857,8 +2104,8 @@ split_go(int loader_slot, int split_slot, void **entry)
     if (sectors == NULL) {
         return SPLIT_GO_ERR;
     }
-    boot_data.imgs[loader_slot].sectors = sectors + 0;
-    boot_data.imgs[split_slot].sectors = sectors + BOOT_MAX_IMG_SECTORS;
+    BOOT_IMG(&boot_data, loader_slot).sectors = sectors + 0;
+    BOOT_IMG(&boot_data, split_slot).sectors = sectors + BOOT_MAX_IMG_SECTORS;
 
     loader_flash_id = flash_area_id_from_image_slot(loader_slot);
     rc = flash_area_open(loader_flash_id,

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -17,6 +17,10 @@
  * under the License.
  */
 
+/*
+ * Modifications are Copyright (c) 2019 Arm Limited.
+ */
+
 /**
  * This file provides an interface to the boot loader.  Functions defined in
  * this file should only be called while the boot loader is running.
@@ -522,6 +526,7 @@ boot_read_status(struct boot_status *bs)
 {
     const struct flash_area *fap;
     uint32_t off;
+    uint8_t swap_info;
     int status_loc;
     int area_id;
     int rc;
@@ -561,13 +566,15 @@ boot_read_status(struct boot_status *bs)
 
     rc = boot_read_status_bytes(fap, bs);
     if (rc == 0) {
-        off = boot_swap_type_off(fap);
-        rc = flash_area_read_is_empty(fap, off, &bs->swap_type,
-                                      sizeof bs->swap_type);
+        off = boot_swap_info_off(fap);
+        rc = flash_area_read_is_empty(fap, off, &swap_info, sizeof swap_info);
         if (rc == 1) {
-            bs->swap_type = BOOT_SWAP_TYPE_NONE;
+            BOOT_SET_SWAP_INFO(swap_info, 0, BOOT_SWAP_TYPE_NONE);
             rc = 0;
         }
+
+        /* Extract the swap type info */
+        bs->swap_type = BOOT_GET_SWAP_TYPE(swap_info);
     }
 
     flash_area_close(fap);
@@ -972,7 +979,9 @@ boot_status_init(const struct flash_area *fap, const struct boot_status *bs)
     assert(rc == 0);
 
     if (bs->swap_type != BOOT_SWAP_TYPE_NONE) {
-        rc = boot_write_swap_type(fap, bs->swap_type);
+        rc = boot_write_swap_info(fap,
+                                  bs->swap_type,
+                                  0);
         assert(rc == 0);
     }
 
@@ -1192,8 +1201,9 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_status *bs)
             }
 
             if (swap_state.swap_type != BOOT_SWAP_TYPE_NONE) {
-                rc = boot_write_swap_type(fap_primary_slot,
-                                          swap_state.swap_type);
+                rc = boot_write_swap_info(fap_primary_slot,
+                                          swap_state.swap_type,
+                                          0);
                 assert(rc == 0);
             }
 

--- a/boot/zephyr/flash_map_extended.c
+++ b/boot/zephyr/flash_map_extended.c
@@ -55,9 +55,12 @@ int flash_device_base(uint8_t fd_id, uintptr_t *ret)
  */
 int flash_area_id_from_image_slot(int slot)
 {
-    static const int area_id_tab[] = {FLASH_AREA_IMAGE_PRIMARY,
-                                      FLASH_AREA_IMAGE_SECONDARY,
-                                      FLASH_AREA_IMAGE_SCRATCH};
+#if (MCUBOOT_IMAGE_NUMBER == 1)
+    static
+#endif
+    const int area_id_tab[] = {FLASH_AREA_IMAGE_PRIMARY,
+                               FLASH_AREA_IMAGE_SECONDARY,
+                               FLASH_AREA_IMAGE_SCRATCH};
 
     if (slot >= 0 && slot < ARRAY_SIZE(area_id_tab)) {
         return area_id_tab[slot];
@@ -68,15 +71,15 @@ int flash_area_id_from_image_slot(int slot)
 
 int flash_area_id_to_image_slot(int area_id)
 {
-    switch (area_id) {
-    case FLASH_AREA_IMAGE_PRIMARY:
+    if (area_id == FLASH_AREA_IMAGE_PRIMARY) {
         return 0;
-    case FLASH_AREA_IMAGE_SECONDARY:
-        return 1;
-    default:
-        BOOT_LOG_ERR("invalid flash area ID");
-        return -1;
     }
+    if (area_id == FLASH_AREA_IMAGE_SECONDARY) {
+        return 1;
+    }
+
+    BOOT_LOG_ERR("invalid flash area ID");
+    return -1;
 }
 
 int flash_area_sector_from_off(off_t off, struct flash_sector *sector)

--- a/boot/zephyr/include/mcuboot_config/mcuboot_config.h
+++ b/boot/zephyr/include/mcuboot_config/mcuboot_config.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018 Open Source Foundries Limited
+ * Copyright (c) 2019 Arm Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -63,6 +64,12 @@
 
 #ifdef CONFIG_BOOT_BOOTSTRAP
 #define MCUBOOT_BOOTSTRAP 1
+#endif
+
+#ifdef CONFIG_UPDATEABLE_IMAGE_NUMBER
+#define MCUBOOT_IMAGE_NUMBER    CONFIG_UPDATEABLE_IMAGE_NUMBER
+#else
+#define MCUBOOT_IMAGE_NUMBER    1
 #endif
 
 /*

--- a/boot/zephyr/include/sysflash/sysflash.h
+++ b/boot/zephyr/include/sysflash/sysflash.h
@@ -4,9 +4,32 @@
 #define __SYSFLASH_H__
 
 #include <generated_dts_board.h>
+#include <mcuboot_config/mcuboot_config.h>
 
+extern uint8_t current_image;
+
+#if (MCUBOOT_IMAGE_NUMBER == 1)
 #define FLASH_AREA_IMAGE_PRIMARY    DT_FLASH_AREA_IMAGE_0_ID
 #define FLASH_AREA_IMAGE_SECONDARY  DT_FLASH_AREA_IMAGE_1_ID
+#elif (MCUBOOT_IMAGE_NUMBER == 2)
+/* MCUBoot currently supports only up to 2 updateable firmware images.
+ * If the number of the current image is greater than MCUBOOT_IMAGE_NUMBER - 1
+ * then a dummy value will be assigned to the flash area macros.
+ */
+#define FLASH_AREA_IMAGE_PRIMARY    ((current_image == 0) ?         \
+                                         DT_FLASH_AREA_IMAGE_0_ID : \
+                                     (current_image == 1) ?         \
+                                         DT_FLASH_AREA_IMAGE_2_ID : \
+                                         255 )
+#define FLASH_AREA_IMAGE_SECONDARY  ((current_image == 0) ?         \
+                                         DT_FLASH_AREA_IMAGE_1_ID : \
+                                     (current_image == 1) ?         \
+                                         DT_FLASH_AREA_IMAGE_3_ID : \
+                                         255 )
+#else
+#error "Image slot and flash area mapping is not defined"
+#endif
+
 #define FLASH_AREA_IMAGE_SCRATCH    DT_FLASH_AREA_IMAGE_SCRATCH_ID
 
 #endif /* __SYSFLASH_H__ */

--- a/boot/zephyr/include/target.h
+++ b/boot/zephyr/include/target.h
@@ -1,5 +1,7 @@
 /*
  *  Copyright (C) 2017, Linaro Ltd
+ *  Copyright (c) 2019, Arm Limited
+ *
  *  SPDX-License-Identifier: Apache-2.0
  */
 
@@ -45,4 +47,11 @@
 #error "Target support is incomplete; cannot build mcuboot."
 #endif
 
+#if ((MCUBOOT_IMAGE_NUMBER == 2) && (!defined(FLASH_AREA_IMAGE_2_OFFSET) || \
+                                     !defined(FLASH_AREA_IMAGE_2_SIZE)   || \
+                                     !defined(FLASH_AREA_IMAGE_3_OFFSET) || \
+                                     !defined(FLASH_AREA_IMAGE_3_SIZE)))
+#error "Target support is incomplete; cannot build mcuboot."
 #endif
+
+#endif /* H_TARGETS_TARGET_ */

--- a/docs/PORTING.md
+++ b/docs/PORTING.md
@@ -86,9 +86,19 @@ struct flash_area {
 `fa_id` is can be one of the following options:
 
 ```c
-#define FLASH_AREA_IMAGE_PRIMARY    1
-#define FLASH_AREA_IMAGE_SECONDARY  2
-#define FLASH_AREA_IMAGE_SCRATCH    3
+/* Independent from multiple image boot */
+#define FLASH_AREA_BOOTLOADER         0
+#define FLASH_AREA_IMAGE_SCRATCH      3
+```
+```c
+/* Flash area IDs of the first image in case of multiple images */
+#define FLASH_AREA_IMAGE_PRIMARY      1
+#define FLASH_AREA_IMAGE_SECONDARY    2
+```
+```c
+/* Flash area IDs of the second image in case of multiple images */
+#define FLASH_AREA_IMAGE_PRIMARY      5
+#define FLASH_AREA_IMAGE_SECONDARY    6
 ```
 
 The functions that must be defined for working with the `flash_area`s are:

--- a/docs/design.md
+++ b/docs/design.md
@@ -116,33 +116,44 @@ region of disk with the following properties:
 2. A write to one area does not restrict writes to other areas.
 
 The boot loader uses the following flash area IDs:
-
-``` c
+```c
+/* Independent from multiple image boot */
 #define FLASH_AREA_BOOTLOADER         0
+#define FLASH_AREA_IMAGE_SCRATCH      3
+```
+```c
+/* If the boot loader is working with the first image */
 #define FLASH_AREA_IMAGE_PRIMARY      1
 #define FLASH_AREA_IMAGE_SECONDARY    2
-#define FLASH_AREA_IMAGE_SCRATCH      3
+```
+```c
+/* If the boot loader is working with the second image */
+#define FLASH_AREA_IMAGE_PRIMARY      5
+#define FLASH_AREA_IMAGE_SECONDARY    6
 ```
 
 The bootloader area contains the bootloader image itself. The other areas are
-described in subsequent sections.
+described in subsequent sections. The flash could contain multiple executable
+images therefore the flash area IDs of primary and secondary areas are mapped
+based on the number of the active image (on which the bootloader is currently
+working).
 
 ## Image Slots
 
-A portion of the flash memory is partitioned into two image slots: a primary
-slot (0) and a secondary slot (1).  The boot loader will only run an image from
-the primary slot, so images must be built such that they can run from that
-fixed location in flash.  If the boot loader needs to run the image resident in
-the secondary slot, it must copy its contents into the primary slot before doing
-so, either by swapping the two images or by overwriting the contents of the
-primary slot. The bootloader supports either swap- or overwrite-based image
-upgrades, but must be configured at build time to choose one of these two
-strategies.
+A portion of the flash memory can be partitioned into multiple image areas, each
+contains two image slots: a primary slot and a secondary slot.
+The boot loader will only run an image from the primary slot, so images must be
+built such that they can run from that fixed location in flash.  If the boot
+loader needs to run the image resident in the secondary slot, it must copy its
+contents into the primary slot before doing so, either by swapping the two
+images or by overwriting the contents of the primary slot. The bootloader
+supports either swap- or overwrite-based image upgrades, but must be configured
+at build time to choose one of these two strategies.
 
-In addition to the two image slots, the boot loader requires a scratch area to
-allow for reliable image swapping. The scratch area must have a size that is
-enough to store at least the largest sector that is going to be swapped. Many
-devices have small equally sized flash sectors, eg 4K, while others have
+In addition to the slots of image areas, the boot loader requires a scratch
+area to allow for reliable image swapping. The scratch area must have a size
+that is enough to store at least the largest sector that is going to be swapped.
+Many devices have small equally sized flash sectors, eg 4K, while others have
 variable sized sectors where the largest sectors might be 128K or 256K, so the
 scratch must be big enough to store that. The scratch is only ever used when
 swapping firmware, which means only when doing an upgrade. Given that, the main

--- a/docs/design.md
+++ b/docs/design.md
@@ -64,12 +64,12 @@ struct image_version {
 struct image_header {
     uint32_t ih_magic;
     uint32_t ih_load_addr;
-    uint16_t ih_hdr_size; /* Size of image header (bytes). */
-    uint16_t _pad2;
-    uint32_t ih_img_size; /* Does not include header. */
-    uint32_t ih_flags;    /* IMAGE_F_[...]. */
+    uint16_t ih_hdr_size;           /* Size of image header (bytes). */
+    uint16_t ih_protect_tlv_size;   /* Size of protected TLV area (bytes). */
+    uint32_t ih_img_size;           /* Does not include header. */
+    uint32_t ih_flags;              /* IMAGE_F_[...]. */
     struct image_version ih_ver;
-    uint32_t _pad3;
+    uint32_t _pad1;
 };
 
 /** Image TLV header.  All fields in little endian. */
@@ -102,10 +102,19 @@ struct image_tlv {
 #define IMAGE_TLV_ECDSA256          0x22   /* ECDSA of hash output */
 #define IMAGE_TLV_RSA3072_PSS       0x23   /* RSA3072 of hash output */
 #define IMAGE_TLV_ED25519           0x24   /* ED25519 of hash output */
+#define IMAGE_TLV_ENC_RSA2048       0x30   /* Key encrypted with RSA-OAEP-2048 */
+#define IMAGE_TLV_ENC_KW128         0x31   /* Key encrypted with AES-KW-128 */
+#define IMAGE_TLV_DEPENDENCY        0x40   /* Image depends on other image */
 ```
 
 Optional type-length-value records (TLVs) containing image metadata are placed
 after the end of the image.
+
+The `ih_protect_tlv_size` field indicates the length of the protected TLV area.
+If dependency TLVs are present then the TLV info header and the dependency TLVs
+are also protected and have to be included in the hash calculation. Otherwise
+the hash is only calculated over the image header and the image itself. In this
+case the value of the `ih_protect_tlv_size` field is 0.
 
 The `ih_hdr_size` field indicates the length of the header, and therefore the
 offset of the image itself.  This field provides for backwards compatibility in
@@ -522,11 +531,15 @@ partitioned further to arrange two slots for each image.
 | Scratch            |
 +--------------------+
 ```
-The multiple image boot procedure is organized in loops which iterate over all
-the firmware images. The high-level overview of the boot process is presented
-below.
-
-Procedure:
+MCUBoot is also capable of handling dependencies between images. For example
+if an image needs to be reverted it might be necessary to revert another one too
+(e.g. due to API incompatibilities) or simply to prevent from being updated
+because of an unsatisfied dependency. Therefore all aborted swaps have to be
+completed and all the swap types have to be determined for each image before
+the dependency checks. Dependency handling is described in more detail in a
+following section. The multiple image boot procedure is organized in loops which
+iterate over all the firmware images. The high-level overview of the boot
+process is presented below.
 
 + ###### Loop 1. Iterate over all images
     1. Inspect swap status region of current image; is an interrupted swap being
@@ -557,9 +570,15 @@ Procedure:
             + Skip to next image.
 
 + ###### Loop 2. Iterate over all images
-    At this point there are no aborted swaps and the swap types are determined
-    for each image.
+    1. Does the current image depend on other image(s)?
+        + Yes: Are all the image dependencies satisfied?
+            + Yes: Skip to next image.
+            + No:
+                + Modify swap type depending on what the previous type was.
+                + Restart dependency check from the first image.
+        + No: Skip to next image.
 
++ ###### Loop 3. Iterate over all images
     1. Is an image swap requested?
         + Yes:
             + Perform image update operation.
@@ -567,8 +586,7 @@ Procedure:
             + Skip to next image.
         + No: Skip to next image.
 
-+ ###### Loop 3. Iterate over all images
-
++ ###### Loop 4. Iterate over all images
     1. Validate image in the primary slot (integrity and security check) or
        at least do a basic sanity check to avoid booting into an empty flash
        area.
@@ -842,3 +860,51 @@ producing signed images, see: [signed_images](signed_images.md).
 
 If you want to enable and use encrypted images, see:
 [encrypted_images](encrypted_images.md).
+
+## Dependency Check
+
+MCUBoot can handle multiple firmware images. It is possible to update them
+independently but in many cases it can be desired to be able to describe
+dependencies between the images (e.g. to ensure API compliance and avoid
+interoperability issues).
+
+The dependencies between images can be described with additional TLV entries in
+the TLV area after the end of an image. There can be more than one dependency
+entry, but in practice if the platform only supports two individual images then
+there can be maximum one entry which reflects to the other image.
+
+If the TLV area contains dependency TLV entries, then these are required to be
+integrity and authenticity protected. In this case the SHA256 has to be
+calculated over not just the image header and the image but also the TLV info
+header and the dependency TLVs.
+```
+A +---------------------+
+  | Header              | <- struct image_header
+  +---------------------+
+  | Payload             |
+  +---------------------+
+  | TLV area            |
+  | +-----------------+ |
+  | | TLV area header | | <- struct image_tlv_info
+  | +-----------------+ |
+  | | Dependency      | | <- Dependency entry (struct image_tlv)
+B | +-----------------+ |
+  | | SHA256 hash     | | <- hash from A - B (struct image_tlv)
+C | +-----------------+ |
+  | | Keyhash         | | <- indicates which pub. key for sig (struct image_tlv)
+  | +-----------------+ |
+  | | Signature       | | <- signature from B - C (struct image_tlv), only hash
+  | +-----------------+ |
+  +---------------------+
+```
+At the phase of dependency check all aborted swaps are finalized if there were
+any. During the dependency check the boot loader verifies whether the image
+dependencies are all satisfied. If at least one of the dependencies of an image
+is not fulfilled then the swap type of that image has to be modified
+accordingly and the dependency check needs to be restarted. This way the number
+of unsatisfied dependencies will decrease or remain the same. There is always at
+least 1 valid configuration. In worst case, the system returns to the initial
+state after dependency check.
+
+For more information on adding dependency entries to an image,
+see: [imgtool](imgtool.md).

--- a/docs/imgtool.md
+++ b/docs/imgtool.md
@@ -58,6 +58,7 @@ primary slot and adds a header and trailer that the bootloader is expecting:
       -k, --key filename
       --align [1|2|4|8]          [required]
       -v, --version TEXT         [required]
+      -d, --dependencies TEXT
       -H, --header-size INTEGER  [required]
       --pad-header               Add --header-size zeroed bytes at the beginning
                                  of the image
@@ -95,3 +96,9 @@ status area size when calculating overflow.
 The optional `--pad` argument will place a trailer on the image that
 indicates that the image should be considered an upgrade.  Writing this image
 in the secondary slot will then cause the bootloader to upgrade to it.
+
+A dependency can be specified in the following way:
+`-d "(image_id, image_version)"`. The `image_id` is the number of the image
+which the current image depends on. The `image_version` is the minimum version
+of that image to satisfy compliance. For example `-d "(1, 1.2.3+0)"` means this
+image depends on Image 1 which version has to be at least 1.2.3+0.

--- a/docs/readme-zephyr.md
+++ b/docs/readme-zephyr.md
@@ -13,13 +13,16 @@ The first step required for Zephyr is making sure your board has flash
 partitions defined in its device tree. These partitions are:
 
 - `boot_partition`: for MCUboot itself
-- `primary_slot_partition`: the primary image slot
-- `secondary_slot_partition`: the secondary image slot
+- `image_0_primary_partition`: the primary slot of Image 0
+- `image_0_secondary_partition`: the secondary slot of Image 0
 - `scratch_partition`: the scratch slot
 
 Currently, the two image slots must be contiguous. If you are running
 MCUboot as your stage 1 bootloader, `boot_partition` must be configured
-so your SoC runs it out of reset.
+so your SoC runs it out of reset. If there are multiple updateable images
+then the corresponding primary and secondary partitions must be defined for
+the rest of the images too (e.g. `image_1_primary_partition` and
+`image_1_secondary_partition` for Image 1).
 
 The flash partitions are typically defined in the Zephyr boards folder, in a
 file named `boards/<arch>/<board>/<board>.dts`. An example `.dts` file with

--- a/samples/mcuboot_config/mcuboot_config.template.h
+++ b/samples/mcuboot_config/mcuboot_config.template.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018 Open Source Foundries Limited
+ * Copyright (c) 2019 Arm Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -81,6 +82,10 @@
 /* Default maximum number of flash sectors per image slot; change
  * as desirable. */
 #define MCUBOOT_MAX_IMG_SECTORS 128
+
+/* Default number of separately updateable images; change in case of
+ * multiple images. */
+#define MCUBOOT_IMAGE_NUMBER 1
 
 /*
  * Logging

--- a/sim/mcuboot-sys/csupport/run.c
+++ b/sim/mcuboot-sys/csupport/run.c
@@ -397,15 +397,15 @@ int flash_area_get_sectors(int fa_id, uint32_t *count,
 
 int flash_area_id_to_image_slot(int area_id)
 {
-    switch (area_id) {
-    case FLASH_AREA_IMAGE_PRIMARY:
+    if (area_id == FLASH_AREA_IMAGE_PRIMARY) {
         return 0;
-    case FLASH_AREA_IMAGE_SECONDARY:
-        return 1;
-    default:
-        printf("Unsupported image area ID\n");
-        abort();
     }
+    if (area_id == FLASH_AREA_IMAGE_SECONDARY) {
+        return 1;
+    }
+
+    printf("Unsupported image area ID\n");
+    abort();
 }
 
 void sim_assert(int x, const char *assertion, const char *file, unsigned int line, const char *function)

--- a/sim/mcuboot-sys/csupport/run.c
+++ b/sim/mcuboot-sys/csupport/run.c
@@ -25,6 +25,8 @@
 #define BOOT_LOG_LEVEL BOOT_LOG_LEVEL_ERROR
 #include <bootutil/bootutil_log.h>
 
+#define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
+
 extern int sim_flash_erase(uint8_t flash_id, uint32_t offset, uint32_t size);
 extern int sim_flash_read(uint8_t flash_id, uint32_t offset, uint8_t *dest,
         uint32_t size);
@@ -242,7 +244,16 @@ void *os_malloc(size_t size)
 
 int flash_area_id_from_image_slot(int slot)
 {
-    return slot + 1;
+    const int area_id_tab[] = {FLASH_AREA_IMAGE_PRIMARY,
+                               FLASH_AREA_IMAGE_SECONDARY,
+                               FLASH_AREA_IMAGE_SCRATCH};
+
+    if (slot >= 0 && (unsigned)slot < ARRAY_SIZE(area_id_tab)) {
+            return area_id_tab[slot];
+    }
+
+    printf("Image flash area ID not found\n");
+    return -1; /* flash_area_open will fail on that */
 }
 
 int flash_area_open(uint8_t id, const struct flash_area **area)

--- a/sim/src/image.rs
+++ b/sim/src/image.rs
@@ -828,11 +828,6 @@ impl Images {
             fails += 1;
         }
 
-        if !self.verify_trailers(&flash, 0, None, None, BOOT_FLAG_UNSET) {
-            warn!("copy_done should be unset");
-            fails += 1;
-        }
-
         let (x, _) = c::boot_go(&mut flash, &self.areadesc, None, false);
         if x != 0 {
             warn!("Should have finished test upgrade");


### PR DESCRIPTION
This change replaces the slot 0/1 terminology with primary/secondary
slot and replaces FLASH_AREA_IMAGE_0/1 with
FLASH_AREA_IMAGE_PRIMARY/SECONDARY. This naming convention
may be more understandable, fits better to MCUs with multiple images
and it is an architecture agnostic alternative as well.

Signed-off-by: David Vincze <david.vincze@arm.com>