### PR TITLE
Fix encrypted support for images with header sizes larger than 256 bytes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ matrix:
       env: MULTI_FEATURES="sig-rsa validate-slot0,sig-ecdsa validate-slot0"
     - os: linux
       env: MULTI_FEATURES="enc-kw overwrite-only,enc-rsa overwrite-only"
+    - os: linux
+      env: MULTI_FEATURES="sig-rsa enc-rsa validate-slot0"
 
     # FIXME: this test actually fails and must be fixed
     #- os: linux

--- a/boot/bootutil/include/bootutil/image.h
+++ b/boot/bootutil/include/bootutil/image.h
@@ -103,6 +103,8 @@ struct image_tlv {
     uint16_t it_len;    /* Data length (not including TLV header). */
 };
 
+#define IS_ENCRYPTED(hdr) ((hdr)->ih_flags & IMAGE_F_ENCRYPTED)
+
 _Static_assert(sizeof(struct image_header) == IMAGE_HEADER_SIZE,
                "struct image_header not required size");
 

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -586,7 +586,7 @@ boot_image_check(struct image_header *hdr, const struct flash_area *fap,
     (void)bs;
     (void)rc;
 #else
-    if (fap->fa_id == FLASH_AREA_IMAGE_1 && hdr->ih_flags & IMAGE_F_ENCRYPTED) {
+    if (fap->fa_id == FLASH_AREA_IMAGE_1 && IS_ENCRYPTED(hdr)) {
         rc = boot_enc_load(hdr, fap, bs->enckey[1]);
         if (rc < 0) {
             return BOOT_EBADIMAGE;
@@ -821,7 +821,7 @@ boot_copy_sector(const struct flash_area *fap_src,
                 hdr = boot_img_hdr(&boot_data, 0);
                 off = off_dst;
             }
-            if (hdr->ih_flags & IMAGE_F_ENCRYPTED) {
+            if (IS_ENCRYPTED(hdr)) {
                 blk_sz = chunk_sz;
                 idx = 0;
                 if (off + bytes_copied < hdr->ih_hdr_size) {
@@ -1136,7 +1136,7 @@ boot_copy_image(struct boot_status *bs)
     }
 
 #ifdef MCUBOOT_ENC_IMAGES
-    if (boot_img_hdr(&boot_data, 1)->ih_flags & IMAGE_F_ENCRYPTED) {
+    if (IS_ENCRYPTED(boot_img_hdr(&boot_data, 1))) {
         rc = boot_enc_load(boot_img_hdr(&boot_data, 1), fap_slot1, bs->enckey[1]);
         if (rc < 0) {
             return BOOT_EBADIMAGE;
@@ -1220,7 +1220,7 @@ boot_copy_image(struct boot_status *bs)
         }
 
 #ifdef MCUBOOT_ENC_IMAGES
-        if (hdr->ih_flags & IMAGE_F_ENCRYPTED) {
+        if (IS_ENCRYPTED(hdr)) {
             fap = BOOT_IMG_AREA(&boot_data, 0);
             rc = boot_enc_load(hdr, fap, bs->enckey[0]);
             assert(rc >= 0);
@@ -1244,7 +1244,7 @@ boot_copy_image(struct boot_status *bs)
 
 #ifdef MCUBOOT_ENC_IMAGES
         hdr = boot_img_hdr(&boot_data, 1);
-        if (hdr->ih_flags & IMAGE_F_ENCRYPTED) {
+        if (IS_ENCRYPTED(hdr)) {
             fap = BOOT_IMG_AREA(&boot_data, 1);
             rc = boot_enc_load(hdr, fap, bs->enckey[1]);
             assert(rc >= 0);

--- a/boot/zephyr/include/mcuboot-mbedtls-cfg.h
+++ b/boot/zephyr/include/mcuboot-mbedtls-cfg.h
@@ -21,7 +21,7 @@
  * the simulator build.rs accordingly.
  */
 
-#ifdef CONFIG_BOOT_SIGNATURE_TYPE_RSA
+#if defined(CONFIG_BOOT_SIGNATURE_TYPE_RSA) || defined(CONFIG_BOOT_ENCRYPT_RSA)
 #include "config-rsa.h"
 #elif defined(CONFIG_BOOT_SIGNATURE_TYPE_ECDSA_P256)
 #include "config-asn1.h"

--- a/boot/zephyr/os.c
+++ b/boot/zephyr/os.c
@@ -29,10 +29,15 @@
 
 /*
  * This is the heap for mbed TLS.  The value needed depends on the key
- * size and algorithm used.  For RSA-2048, 6144 bytes seems to be
- * enough.
+ * size and algorithm used.  For RSA-2048 signing, 6144 bytes seems to be
+ * enough. When using RSA-2048-OAEP encryption + RSA-2048 signing, 10240
+ * bytes seem to be enough.
  */
+#if !defined(CONFIG_BOOT_ENCRYPT_RSA)
 #define CRYPTO_HEAP_SIZE 6144
+#else
+#define CRYPTO_HEAP_SIZE 10240
+#endif
 
 static unsigned char mempool[CRYPTO_HEAP_SIZE];
 

--- a/sim/mcuboot-sys/build.rs
+++ b/sim/mcuboot-sys/build.rs
@@ -35,7 +35,6 @@ fn main() {
         conf.define("MCUBOOT_SIGN_RSA", None);
         conf.define("MCUBOOT_USE_MBED_TLS", None);
 
-        conf.define("MBEDTLS_CONFIG_FILE", Some("<config-rsa.h>"));
         conf.include("mbedtls/include");
         conf.file("mbedtls/library/sha256.c");
         conf.file("csupport/keys.c");
@@ -49,7 +48,6 @@ fn main() {
         conf.define("MCUBOOT_SIGN_EC256", None);
         conf.define("MCUBOOT_USE_TINYCRYPT", None);
 
-        conf.define("MBEDTLS_CONFIG_FILE", Some("<config-asn1.h>"));
         conf.include("../../ext/mbedtls/include");
         conf.include("../../ext/tinycrypt/lib/include");
 
@@ -79,7 +77,6 @@ fn main() {
         conf.define("MCUBOOT_ENCRYPT_RSA", None);
         conf.define("MCUBOOT_ENC_IMAGES", None);
         conf.define("MCUBOOT_USE_MBED_TLS", None);
-        conf.define("MBEDTLS_CONFIG_FILE", Some("<config-rsa.h>"));
 
         conf.file("../../boot/bootutil/src/encrypted.c");
         conf.file("csupport/keys.c");
@@ -102,7 +99,6 @@ fn main() {
         conf.define("MCUBOOT_ENCRYPT_KW", None);
         conf.define("MCUBOOT_ENC_IMAGES", None);
         conf.define("MCUBOOT_USE_MBED_TLS", None);
-        conf.define("MBEDTLS_CONFIG_FILE", Some("<config-kw.h>"));
 
         conf.file("../../boot/bootutil/src/encrypted.c");
         conf.file("csupport/keys.c");
@@ -116,6 +112,14 @@ fn main() {
         conf.file("mbedtls/library/cipher.c");
         conf.file("mbedtls/library/cipher_wrap.c");
         conf.file("mbedtls/library/aes.c");
+    }
+
+    if sig_rsa || enc_rsa {
+        conf.define("MBEDTLS_CONFIG_FILE", Some("<config-rsa.h>"));
+    } else if sig_ecdsa {
+        conf.define("MBEDTLS_CONFIG_FILE", Some("<config-asn1.h>"));
+    } else if enc_kw {
+        conf.define("MBEDTLS_CONFIG_FILE", Some("<config-kw.h>"));
     }
 
     conf.file("../../boot/bootutil/src/image_validate.c");

--- a/sim/src/lib.rs
+++ b/sim/src/lib.rs
@@ -1011,11 +1011,13 @@ fn install_image(flash: &mut Flash, slots: &[SlotInfo], slot: usize, len: usize,
 
     let mut tlv = make_tlv();
 
+    const HDR_SIZE: usize = 32;
+
     // Generate a boot header.  Note that the size doesn't include the header.
     let header = ImageHeader {
         magic: 0x96f3b83d,
         load_addr: 0,
-        hdr_size: 32,
+        hdr_size: HDR_SIZE as u16,
         _pad1: 0,
         img_size: len as u32,
         flags: tlv.get_flags(),
@@ -1028,13 +1030,11 @@ fn install_image(flash: &mut Flash, slots: &[SlotInfo], slot: usize, len: usize,
         _pad2: 0,
     };
 
-    let b_header = header.as_raw();
+    let mut b_header = [0; HDR_SIZE];
+    b_header[..32].clone_from_slice(header.as_raw());
+    assert_eq!(b_header.len(), HDR_SIZE);
+
     tlv.add_bytes(&b_header);
-    /*
-    let b_header = unsafe { slice::from_raw_parts(&header as *const _ as *const u8,
-                                                  mem::size_of::<ImageHeader>()) };
-                                                  */
-    assert_eq!(b_header.len(), 32);
 
     // The core of the image itself is just pseudorandom data.
     let mut b_img = vec![0; len];

--- a/sim/src/lib.rs
+++ b/sim/src/lib.rs
@@ -1139,6 +1139,7 @@ fn install_image(flash: &mut Flash, slots: &[SlotInfo], slot: usize, len: usize,
 
 // The TLV in use depends on what kind of signature we are verifying.
 #[cfg(feature = "sig-rsa")]
+#[cfg(not(feature = "enc-rsa"))]
 fn make_tlv() -> TlvGen {
     TlvGen::new_rsa_pss()
 }
@@ -1148,9 +1149,16 @@ fn make_tlv() -> TlvGen {
     TlvGen::new_ecdsa()
 }
 
+#[cfg(not(feature = "sig-rsa"))]
 #[cfg(feature = "enc-rsa")]
 fn make_tlv() -> TlvGen {
     TlvGen::new_enc_rsa()
+}
+
+#[cfg(feature = "sig-rsa")]
+#[cfg(feature = "enc-rsa")]
+fn make_tlv() -> TlvGen {
+    TlvGen::new_sig_enc_rsa()
 }
 
 #[cfg(feature = "enc-kw")]

--- a/sim/src/tlv.rs
+++ b/sim/src/tlv.rs
@@ -61,8 +61,8 @@ impl TlvGen {
     pub fn new_rsa_pss() -> TlvGen {
         TlvGen {
             flags: 0,
-            kinds: vec![TlvKinds::SHA256, TlvKinds::KEYHASH, TlvKinds::RSA2048],
-            size: 4 + 32 + 4 + 256,
+            kinds: vec![TlvKinds::SHA256, TlvKinds::RSA2048],
+            size: 4 + 32 + 4 + 32 + 4 + 256,
             payload: vec![],
         }
     }
@@ -71,8 +71,8 @@ impl TlvGen {
     pub fn new_ecdsa() -> TlvGen {
         TlvGen {
             flags: 0,
-            kinds: vec![TlvKinds::SHA256, TlvKinds::KEYHASH, TlvKinds::ECDSA256],
-            size: 4 + 32 + 4 + 72,
+            kinds: vec![TlvKinds::SHA256, TlvKinds::ECDSA256],
+            size: 4 + 32 + 4 + 32 + 4 + 72,
             payload: vec![],
         }
     }
@@ -83,6 +83,16 @@ impl TlvGen {
             flags: TlvFlags::ENCRYPTED as u32,
             kinds: vec![TlvKinds::SHA256, TlvKinds::ENCRSA2048],
             size: 4 + 32 + 4 + 256,
+            payload: vec![],
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn new_sig_enc_rsa() -> TlvGen {
+        TlvGen {
+            flags: TlvFlags::ENCRYPTED as u32,
+            kinds: vec![TlvKinds::SHA256, TlvKinds::RSA2048, TlvKinds::ENCRSA2048],
+            size: 4 + 32 + 4 + 32 + 4 + 256 + 4 + 256,
             payload: vec![],
         }
     }


### PR DESCRIPTION
The visible issue here is that there was an assert checking header size against a buffer that was supposed to run only on encrypted images but was missing the `#ifdef`ery. This cause images with headers larger than 256 bytes to fail, regardless of the encrypted image setting.

This patch fixes the issue by adding correct support for encrypted images, regardless of the header size.

I added a patch to the simulator to run the testing with header size equal to 512 bytes, which I will drop before merging this PR, although I find it valuable to have a test like this, a better way to parametrize this has to be found, and also avoid running every test both on 32 and 512 byte headers.