### PR TITLE
Remove unused hal includes from bootutil

### DIFF
--- a/boot/bootutil/src/bootutil_misc.c
+++ b/boot/bootutil/src/bootutil_misc.c
@@ -23,12 +23,8 @@
 #include <stddef.h>
 
 #include "sysflash/sysflash.h"
-#include "hal/hal_bsp.h"
-#include "hal/hal_flash.h"
-
 #include "flash_map_backend/flash_map_backend.h"
 
-#include "os/os.h"
 #include "bootutil/image.h"
 #include "bootutil/bootutil.h"
 #include "bootutil_priv.h"

--- a/boot/bootutil/src/image_validate.c
+++ b/boot/bootutil/src/image_validate.c
@@ -22,8 +22,6 @@
 #include <inttypes.h>
 #include <string.h>
 
-#include "hal/hal_flash.h"
-
 #include <flash_map_backend/flash_map_backend.h>
 
 #include "bootutil/image.h"


### PR DESCRIPTION
While porting MCUboot to a bare matel chip without OS (NXP LPC824) I found some unused includes.

After this pull request only four headers are required for a new target system:
"sysflash/sysfash.h"
"flash_map_backend/flash_map_backend.h"
"mcuboot_config/mcuboot_config.h"
"os/malloc.h"

The header "os/malloc.h" is only required by the split_go() function.
I my port I also removed split_go() but I’m not sure what it does so I kept it here.

Let’s see if CI passes or if I missed some details.