### PR TITLE
Move to Rust2018

### DIFF
--- a/sim/Cargo.lock
+++ b/sim/Cargo.lock
@@ -100,7 +100,7 @@ dependencies = [
  "docopt 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mcuboot-sys 0.1.0",
  "pem 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -245,7 +245,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lazy_static"
-version = "1.0.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -259,13 +259,21 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "log"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "mcuboot-sys"
 version = "0.1.0"
 dependencies = [
  "cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "simflash 0.1.0",
 ]
 
@@ -297,7 +305,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -408,7 +416,7 @@ name = "simflash"
 version = "0.1.0"
 dependencies = [
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -448,7 +456,7 @@ name = "thread_local"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -524,9 +532,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
-"checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
+"checksum lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1"
 "checksum libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)" = "36fbc8a8929c632868295d0178dd8f63fc423fd7537ad0738372bd010b3ac9b0"
 "checksum log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "880f77541efa6e5cc74e76910c9884d9859683118839d6a1dc3b11e63512565b"
+"checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
 "checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
 "checksum num_cpus 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "514f0d73e64be53ff320680ca671b64fe3fb91da01e1ae2ddc99eb51d453b20d"
 "checksum opaque-debug 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d620c9c26834b34f039489ac0dfdb12c7ac15ccaf818350a64c9b5334a452ad7"

--- a/sim/Cargo.toml
+++ b/sim/Cargo.toml
@@ -20,7 +20,7 @@ rand = "0.3.0"
 docopt = "0.8"
 serde = "1.0"
 serde_derive = "1.0"
-log = "0.3"
+log = "0.4"
 env_logger = "0.4"
 simflash = { path = "simflash" }
 mcuboot-sys = { path = "mcuboot-sys" }

--- a/sim/Cargo.toml
+++ b/sim/Cargo.toml
@@ -2,6 +2,7 @@
 name = "bootsim"
 version = "0.1.0"
 authors = ["David Brown <davidb@davidb.org>"]
+edition = "2018"
 
 [features]
 default = []

--- a/sim/mcuboot-sys/Cargo.toml
+++ b/sim/mcuboot-sys/Cargo.toml
@@ -39,7 +39,7 @@ cc = "1.0.25"
 [dependencies]
 lazy_static = "1.2"
 libc = "0.2.0"
-log = "0.3"
+log = "0.4"
 simflash = { path = "../simflash" }
 
 # Optimize some, even when building for debugging, otherwise the tests

--- a/sim/mcuboot-sys/Cargo.toml
+++ b/sim/mcuboot-sys/Cargo.toml
@@ -36,7 +36,7 @@ bootstrap = []
 cc = "1.0.25"
 
 [dependencies]
-lazy_static = "1.0"
+lazy_static = "1.2"
 libc = "0.2.0"
 log = "0.3"
 simflash = { path = "../simflash" }

--- a/sim/mcuboot-sys/Cargo.toml
+++ b/sim/mcuboot-sys/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["David Brown <david.brown@linaro.org>"]
 description = "A simple wrapper around the mcuboot code."
 build = "build.rs"
 publish = false
+edition = "2018"
 
 [features]
 # By default, build with simplistic signature verification.

--- a/sim/mcuboot-sys/src/c.rs
+++ b/sim/mcuboot-sys/src/c.rs
@@ -1,9 +1,9 @@
 /// Interface wrappers to C API entering to the bootloader
 
-use area::AreaDesc;
+use crate::area::AreaDesc;
 use simflash::SimFlashMap;
 use libc;
-use api;
+use crate::api;
 use std::sync::Mutex;
 
 lazy_static! {
@@ -85,7 +85,7 @@ pub fn kw_encrypt(kek: &[u8], seckey: &[u8]) -> Result<[u8; 24], &'static str> {
 }
 
 mod raw {
-    use area::CAreaDesc;
+    use crate::area::CAreaDesc;
     use libc;
 
     extern "C" {

--- a/sim/mcuboot-sys/src/c.rs
+++ b/sim/mcuboot-sys/src/c.rs
@@ -2,6 +2,7 @@
 
 use crate::area::AreaDesc;
 use simflash::SimFlashMap;
+use lazy_static::lazy_static;
 use libc;
 use crate::api;
 use std::sync::Mutex;

--- a/sim/mcuboot-sys/src/lib.rs
+++ b/sim/mcuboot-sys/src/lib.rs
@@ -10,4 +10,4 @@ pub mod c;
 // functions are exported to C code.
 pub mod api;
 
-pub use area::{AreaDesc, FlashId};
+pub use crate::area::{AreaDesc, FlashId};

--- a/sim/mcuboot-sys/src/lib.rs
+++ b/sim/mcuboot-sys/src/lib.rs
@@ -1,8 +1,3 @@
-#[macro_use] extern crate lazy_static;
-extern crate libc;
-#[macro_use] extern crate log;
-extern crate simflash;
-
 mod area;
 pub mod c;
 

--- a/sim/simflash/Cargo.toml
+++ b/sim/simflash/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2018"
 [dependencies]
 error-chain = "0.12.0"
 rand = "0.3.0"
-log = "0.3"
+log = "0.4"

--- a/sim/simflash/Cargo.toml
+++ b/sim/simflash/Cargo.toml
@@ -2,6 +2,7 @@
 name = "simflash"
 version = "0.1.0"
 authors = ["David Brown <david.brown@linaro.org>"]
+edition = "2018"
 
 [dependencies]
 error-chain = "0.12.0"

--- a/sim/simflash/src/lib.rs
+++ b/sim/simflash/src/lib.rs
@@ -15,7 +15,7 @@ use std::iter::Enumerate;
 use std::path::Path;
 use std::slice;
 use std::collections::HashMap;
-use pdump::HexDump;
+use crate::pdump::HexDump;
 
 error_chain! {
     errors {

--- a/sim/src/lib.rs
+++ b/sim/src/lib.rs
@@ -1,28 +1,24 @@
-#[macro_use] extern crate log;
-extern crate ring;
-extern crate aes_ctr;
-extern crate base64;
-extern crate env_logger;
-extern crate docopt;
-extern crate libc;
-extern crate pem;
-extern crate rand;
-#[macro_use] extern crate serde_derive;
-extern crate serde;
-extern crate simflash;
-extern crate untrusted;
-extern crate mcuboot_sys;
-
 use docopt::Docopt;
-use rand::{Rng, SeedableRng, XorShiftRng};
-use rand::distributions::{IndependentSample, Range};
-use std::fmt;
-use std::mem;
-use std::process;
-use std::slice;
-use aes_ctr::Aes128Ctr;
-use aes_ctr::stream_cipher::generic_array::GenericArray;
-use aes_ctr::stream_cipher::{NewFixStreamCipher, StreamCipherCore};
+use log::{info, warn, error};
+use rand::{
+    distributions::{IndependentSample, Range},
+    Rng, SeedableRng, XorShiftRng,
+};
+use std::{
+    fmt,
+    mem,
+    process,
+    slice,
+};
+use aes_ctr::{
+    Aes128Ctr,
+    stream_cipher::{
+        generic_array::GenericArray,
+        NewFixStreamCipher,
+        StreamCipherCore,
+    },
+};
+use serde_derive::Deserialize;
 
 mod caps;
 mod tlv;
@@ -73,7 +69,7 @@ pub static ALL_DEVICES: &'static [DeviceName] = &[
 ];
 
 impl fmt::Display for DeviceName {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             DeviceName::Stm32f4 => "stm32f4",
             DeviceName::K64f => "k64f",
@@ -93,7 +89,7 @@ struct AlignArgVisitor;
 impl<'de> serde::de::Visitor<'de> for AlignArgVisitor {
     type Value = AlignArg;
 
-    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str("1, 2, 4 or 8")
     }
 
@@ -1033,7 +1029,7 @@ fn try_random_fails(flashmap: &SimFlashMap, images: &Images,
 
 /// Show the flash layout.
 #[allow(dead_code)]
-fn show_flash(flash: &Flash) {
+fn show_flash(flash: &dyn Flash) {
     println!("---- Flash configuration ----");
     for sector in flash.sector_iter() {
         println!("    {:3}: 0x{:08x}, 0x{:08x}",

--- a/sim/src/lib.rs
+++ b/sim/src/lib.rs
@@ -30,8 +30,8 @@ pub mod testlog;
 
 use simflash::{Flash, SimFlash, SimFlashMap};
 use mcuboot_sys::{c, AreaDesc, FlashId};
-use caps::Caps;
-use tlv::{TlvGen, TlvFlags, AES_SEC_KEY};
+use crate::caps::Caps;
+use crate::tlv::{TlvGen, TlvFlags, AES_SEC_KEY};
 
 const USAGE: &'static str = "
 Mcuboot simulator

--- a/sim/src/main.rs
+++ b/sim/src/main.rs
@@ -1,6 +1,6 @@
-extern crate env_logger;
+use env_logger;
 
-extern crate bootsim;
+use bootsim;
 
 fn main() {
     env_logger::init().unwrap();

--- a/sim/tests/core.rs
+++ b/sim/tests/core.rs
@@ -2,8 +2,6 @@
 //!
 //! Run the existing testsuite as a Rust unit test.
 
-extern crate bootsim;
-
 use bootsim::{Run, testlog};
 
 macro_rules! sim_test {


### PR DESCRIPTION
Rust 2018 is now part of the stable compiler.  The 2018 brings numerous minor improvements, along with a few significant ones (such as non-lexical lifetimes).  This patchset migrates to code of the simulator to work with Rust 2018.  There are typically two patches for each crate, one that applies the minimal changes to allow the code to work with Rust 2018, and another that then makes the code more idiomatic. Both are largely automated, using commands described in the commit messages.