### PR TITLE
zephyr: boot_serial: fix crc header warning

### DIFF
--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -31,7 +31,7 @@
 #include <misc/byteorder.h>
 #include <misc/__assert.h>
 #include <flash.h>
-#include <crc16.h>
+#include <crc.h>
 #include <base64.h>
 #include <cbor.h>
 #else


### PR DESCRIPTION
The `crc16.h` header has been deprecated in favor of `crc.h`.
Include the new header to prevent the warning.