### PR TITLE
boot: zephyr: pca10059: disable logging by default

### DIFF
--- a/boot/zephyr/boards/nrf52840_pca10059.conf
+++ b/boot/zephyr/boards/nrf52840_pca10059.conf
@@ -1,3 +1,8 @@
+# The UART is used for Serial Recovery, so logging requires
+# an RTT console, which is not available out of the box on this board.
+# Disable logging.
+CONFIG_BOOT_HAVE_LOGGING=n
+
 # Serial
 CONFIG_SERIAL=y
 CONFIG_UART_NRFX=y
@@ -10,10 +15,6 @@ CONFIG_MCUBOOT_SERIAL=y
 CONFIG_BOOT_SERIAL_CDC_ACM=y
 CONFIG_BOOT_SERIAL_DETECT_PORT="GPIO_1"
 CONFIG_BOOT_SERIAL_DETECT_PIN=6
-
-# RTT console
-CONFIG_RTT_CONSOLE=y
-CONFIG_USB_UART_CONSOLE=n
 
 # Required by USB
 CONFIG_MULTITHREADING=y


### PR DESCRIPTION
The board cannot output logs on the UART because it is used by MCUBoot's serial recovery for DFU. Remove logging and the RTT console from project defaults.
