### PR TITLE
Fix Mynewt builds; add log stub dependency

### DIFF
--- a/boot/boot_serial/test/pkg.yml
+++ b/boot/boot_serial/test/pkg.yml
@@ -25,6 +25,7 @@ pkg.keywords:
 pkg.deps:
     - "@mcuboot/boot/boot_serial"
     - "@mcuboot/boot/bootutil"
+    - "@apache-mynewt-core/sys/log/stub"
     - "@apache-mynewt-core/test/testutil"
 
 pkg.deps.SELFTEST:

--- a/boot/mynewt/pkg.yml
+++ b/boot/mynewt/pkg.yml
@@ -33,6 +33,7 @@ pkg.deps:
     - "@mcuboot/boot/bootutil"
     - "@mcuboot/boot/mynewt/flash_map_backend"
     - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/sys/log/stub"
 
 pkg.deps.BOOTUTIL_NO_LOGGING:
     - "@apache-mynewt-core/sys/console/stub"


### PR DESCRIPTION
A recent change in the Mynewt repo (`b10cbea5ef882e7f91d1c34ffcf2506d3e183003`) imposes the LOG API requirement on the `sys/mfg` package.  To fix broken builds, make the Mynewt app and test package depend on `sys/log/stub`.