### PR TITLE
boot: zephyr: select GPIO when MCUBOOT_SERIAL is enabled

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -143,8 +143,9 @@ menuconfig MCUBOOT_SERIAL
 	bool "MCUboot serial recovery"
 	default n
 	select REBOOT
-	select UART_INTERRUPT_DRIVEN
+	select GPIO
 	select SERIAL
+	select UART_INTERRUPT_DRIVEN
 	select BASE64
 	select TINYCBOR
 	help


### PR DESCRIPTION
Select GPIO when MCUBOOT_SERIAL is enabled, so that the bootloader won't hardfault when trying to obtain the bindings to the GPIO driver.

@nvlsianpu have a look when you can, thank you.