### PR TITLE
samples/zephyr: Build ECDSA tests with ECDSA key

### DIFF
--- a/samples/zephyr/overlay-ecdsa-p256.conf
+++ b/samples/zephyr/overlay-ecdsa-p256.conf
@@ -1,2 +1,3 @@
 # Kconfig overlay for building with ECDSA-P256 signatures
 CONFIG_BOOT_SIGNATURE_TYPE_ECDSA_P256=y
+CONFIG_BOOT_SIGNATURE_KEY_FILE="root-ec-p256.pem"


### PR DESCRIPTION
Set the public key for ECDSA tests to use the ECDSA.  This avoids a link
error with:

    ../app/libapp.a(keys.c.obj):(.rodata.bootutil_keys+0x0): undefined reference to `ecdsa_pub_key'
    ../app/libapp.a(keys.c.obj):(.rodata.bootutil_keys+0x4): undefined reference to `ecdsa_pub_key_len'

Signed-off-by: David Brown <david.brown@linaro.org>