### PR TITLE
[Mynewt] repository.yml: Remove invalid stability "rc1"

### DIFF
--- a/repository.yml
+++ b/repository.yml
@@ -24,7 +24,7 @@ repo.versions:
     "1.0.0": "v1.0.0"
     "1.1.0": "v1.1.0"
     "1.2.0": "v1.2.0"
-    "1.3.0-rc1": "v1.3.0-rc1"
+    "1.3.0": "v1.3.0-rc1"
 
     "0-dev": "0.0.0"        # master
     "0-latest": "1.2.0"     # latest stable release


### PR DESCRIPTION
Newt only allows the following stability strings in a repo version:

    VERSION_STABILITY_NONE   = ""
    VERSION_STABILITY_STABLE = "stable"
    VERSION_STABILITY_DEV    = "dev"
    VERSION_STABILITY_LATEST = "latest"
    VERSION_STABILITY_COMMIT = "commit"

An attempt to update a project that uses mcuboot would choke due to the invalid stability string "rc1":

```
Error: Unknown stability (rc1) in version 1.3.0-rc1
```