### PR TITLE
Do not use an ASSERT to catch the case if no image is loaded

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -1734,7 +1734,6 @@ boot_go(struct boot_rsp *rsp)
 
 #ifdef MCUBOOT_VALIDATE_SLOT0
     rc = boot_validate_slot(0, NULL);
-    ASSERT(rc == 0);
     if (rc != 0) {
         rc = BOOT_EBADIMAGE;
         goto out;


### PR DESCRIPTION
In case if no image is loaded and the `MCUBOOT_VALIDATE_SLOT0` is enabled, the current implementation will stuck at this assertion. This means when assertions will be evaluated that the if-statement after the assertion is dead code.  I think no image loaded shouldn't be a case which will be catched with an assertion.  
What do you think ?