### PR TITLE
zephyr:board: squash nrf51_pca10028 flash footprint

### DIFF
--- a/boot/zephyr/boards/nrf51_pca10028.conf
+++ b/boot/zephyr/boards/nrf51_pca10028.conf
@@ -1,0 +1,5 @@
+# Due the small boot partition can't use logging and debug optimalization
+# out-off-the-box. For using these features need to increase boot partition via
+# zephyr DTS.
+CONFIG_BOOT_HAVE_LOGGING=n
+CONFIG_SIZE_OPTIMIZATIONS=y


### PR DESCRIPTION
Disable logging and enable size optimizations on
nrf51_pca10028 target in order to fit in boot slot size
for out-off-the-box build.

fixes #411

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>