### PR TITLE
Set pending: don't crash when image slot corrupt

### DIFF
--- a/boot/bootutil/src/bootutil_misc.c
+++ b/boot/bootutil/src/bootutil_misc.c
@@ -615,10 +615,22 @@ boot_set_pending(int permanent)
         flash_area_close(fap);
         return rc;
 
+    case BOOT_MAGIC_BAD:
+        /* The image slot is corrupt.  There is no way to recover, so erase the
+         * slot to allow future upgrades.
+         */
+        rc = flash_area_open(FLASH_AREA_IMAGE_1, &fap);
+        if (rc != 0) {
+            return BOOT_EFLASH;
+        }
+
+        flash_area_erase(fap, 0, fap->fa_size);
+        flash_area_close(fap);
+        return BOOT_EBADIMAGE;
+
     default:
-        /* XXX: Temporary assert. */
         assert(0);
-        return -1;
+        return BOOT_EBADIMAGE;
     }
 }
 


### PR DESCRIPTION
This change affects the "set pending" operation.  That is, the operation that configures mcuboot to temporarily swap images on the next boot.

#### PRIOR TO PR

If the slot 1 trailer contained an invalid 128-bit magic number, an assertion would fail, causing a crash.

#### AFTER PR

If corruption is detected in the slot 1 trailer, the entire image slot is erased, and the "set pending" operation fails with a `BOOT_EBADIMAGE` status.

#### RATIONALE

mcuboot cannot meaningfully recover from data corruption.  The only recourse is to erase the bad data so that future upgrades can be performed.  I was tempted to add a build-time setting to control whether the image slot gets erased when corruption is detected, but I dont think this
freedom justifies the cost of extra config.  A device with a corrupt image slot can no longer be upgraded, so the only reason someone would want to preserve the corrupt data would be for debugging.

#### NOTES

I think mcuboot should detect this type of corruption at startup and erase the bad image slot itself.  This requires some further discussion and can be addressed later.