### PR TITLE
Add Mynewt configuration to enable HW crypto

### DIFF
--- a/boot/bootutil/pkg.yml
+++ b/boot/bootutil/pkg.yml
@@ -31,6 +31,9 @@ pkg.apis:
 pkg.cflags:
     - "-DMCUBOOT_MYNEWT"
 
+pkg.cflags.BOOTUTIL_USE_MBED_TLS:
+    - '-DMBEDTLS_USER_CONFIG_FILE="mbedtls/config_mynewt.h"'
+
 pkg.deps:
     - "@mcuboot/boot/mynewt/mcuboot_config"
     - "@apache-mynewt-core/hw/hal"

--- a/boot/mynewt/src/main.c
+++ b/boot/mynewt/src/main.c
@@ -218,8 +218,8 @@ main(void)
     assert(rc == 0);
 #endif
 
-#if defined(MCUBOOT_SERIAL) || defined(MCUBOOT_HAVE_LOGGING)
-    /* initialize uart without os */
+#if defined(MCUBOOT_SERIAL) || defined(MCUBOOT_HAVE_LOGGING) || MYNEWT_VAL(CRYPTO)
+    /* initialize uart/crypto without os */
     os_dev_initialize_all(OS_DEV_INIT_PRIMARY);
     os_dev_initialize_all(OS_DEV_INIT_SECONDARY);
     sysinit();


### PR DESCRIPTION
This changes are required to fix build on Mynewt when using the HW crypto framework (currently a proposal available here: https://github.com/apache/mynewt-core/pull/1649)

Signed-off-by: Fabio Utzig <utzig@apache.org>