### PR TITLE
zephyr: fix build with zephyr

### DIFF
--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -588,7 +588,11 @@ boot_serial_in_dec(char *in, int inlen, char *out, int *out_off, int maxout)
         if (len != *out_off - sizeof(uint16_t)) {
             return 0;
         }
-        len = min(len, *out_off - sizeof(uint16_t));
+
+        if (len > *out_off - sizeof(uint16_t)) {
+            len = *out_off - sizeof(uint16_t);
+        }
+
         out += sizeof(uint16_t);
 #ifdef __ZEPHYR__
         crc = crc16(out, len, CRC_CITT_POLYMINAL, CRC16_INITIAL_CRC, true);

--- a/boot/zephyr/serial_adapter.c
+++ b/boot/zephyr/serial_adapter.c
@@ -193,7 +193,7 @@ boot_uart_fifo_init(void)
 #ifdef CONFIG_BOOT_SERIAL_UART
 	uart_dev = device_get_binding(CONFIG_UART_CONSOLE_ON_DEV_NAME);
 #elif CONFIG_BOOT_SERIAL_CDC_ACM
-	uart_dev = device_get_binding(CONFIG_CDC_ACM_PORT_NAME);
+	uart_dev = device_get_binding(CONFIG_CDC_ACM_PORT_NAME_0);
 #endif
 	u8_t c;
 


### PR DESCRIPTION
zephyr macro min() was hanged to MIN()
Kconfig key CDC_ACM_PORT_NAME was changed to CDC_ACM_PORT_NAME_0

zephyr sha of the fixing time is https://github.com/zephyrproject-rtos/zephyr/commit/406dc2cb0e2868392f444677ace416440695829f.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>