### PR TITLE
zephyr: align uart device name

### DIFF
--- a/boot/zephyr/serial_adapter.c
+++ b/boot/zephyr/serial_adapter.c
@@ -191,7 +191,7 @@ static int
 boot_uart_fifo_init(void)
 {
 #ifdef CONFIG_BOOT_SERIAL_UART
-	uart_dev = device_get_binding(CONFIG_UART_CONSOLE_ON_DEV_NAME);
+	uart_dev = device_get_binding(DT_UART_CONSOLE_ON_DEV_NAME);
 #elif CONFIG_BOOT_SERIAL_CDC_ACM
 	uart_dev = device_get_binding(CONFIG_CDC_ACM_PORT_NAME_0);
 #endif


### PR DESCRIPTION
Zephyr changed way of generation UART device name label
which implies device name label text change.

Patch aligns the code to above change.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>