### PR TITLE
zephyr: cmake: Don't declare the deprecated macro set_conf_file

### DIFF
--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -6,18 +6,6 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 
-# Board-specific CONF_FILES should get merged into the build as well.
-#
-# Do this by defining the set_conf_file macro:
-# http://docs.zephyrproject.org/application/application.html#application-configuration
-macro(set_conf_file)
-  if (EXISTS ${APPLICATION_SOURCE_DIR}/boards/${BOARD}.conf)
-    set(CONF_FILE "prj.conf ${APPLICATION_SOURCE_DIR}/boards/${BOARD}.conf")
-  else()
-    set(CONF_FILE prj.conf)
-  endif()
-endmacro()
-
 # Default to qemu_x86 if no board has been specified.
 set(BOARD qemu_x86)
 


### PR DESCRIPTION
The pattern that 'set_conf_file' has been added to the Zephyr build
system, so it is not necesary for the application build script to
implement it.

Also, the macro has been deprecated, so it should not be used.

This change is a pure refactoring.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>