### PR TITLE
image encryption: fix enc_state array indexing for zephyr

### DIFF
--- a/boot/bootutil/include/bootutil/enc_key.h
+++ b/boot/bootutil/include/bootutil/enc_key.h
@@ -20,6 +20,7 @@
 #ifndef BOOTUTIL_ENC_KEY_H
 #define BOOTUTIL_ENC_KEY_H
 
+#include <stdbool.h>
 #include <flash_map_backend/flash_map_backend.h>
 #include "mcuboot_config/mcuboot_config.h"
 #include "bootutil/image.h"
@@ -51,7 +52,7 @@ extern const struct bootutil_key bootutil_enc_key;
 int boot_enc_set_key(uint8_t slot, uint8_t *enckey);
 int boot_enc_load(const struct image_header *hdr, const struct flash_area *fap,
         uint8_t *enckey);
-int boot_enc_valid(const struct flash_area *fap);
+bool boot_enc_valid(const struct flash_area *fap);
 void boot_encrypt(const struct flash_area *fap, uint32_t off, uint32_t sz,
         uint32_t blk_off, uint8_t *buf);
 void boot_enc_zeroize(void);

--- a/boot/bootutil/src/encrypted.c
+++ b/boot/bootutil/src/encrypted.c
@@ -306,7 +306,7 @@ boot_enc_load(const struct image_header *hdr, const struct flash_area *fap,
     return rc;
 }
 
-int
+bool
 boot_enc_valid(const struct flash_area *fap)
 {
     int rc;
@@ -315,7 +315,7 @@ boot_enc_valid(const struct flash_area *fap)
     if (rc < 0) {
         /* can't get proper slot number - skip encryption, */
         /* postpone the erro for a upper layer */
-        return 0;
+        return false;
     }
 
     return enc_state[rc].valid;

--- a/boot/zephyr/flash_map_extended.c
+++ b/boot/zephyr/flash_map_extended.c
@@ -66,6 +66,19 @@ int flash_area_id_from_image_slot(int slot)
     return -EINVAL; /* flash_area_open will fail on that */
 }
 
+int flash_area_id_to_image_slot(int area_id)
+{
+    switch (area_id) {
+    case FLASH_AREA_IMAGE_PRIMARY:
+        return 0;
+    case FLASH_AREA_IMAGE_SECONDARY:
+        return 1;
+    default:
+        BOOT_LOG_ERR("invalid flash area ID");
+        return -1;
+    }
+}
+
 int flash_area_sector_from_off(off_t off, struct flash_sector *sector)
 {
     int rc;

--- a/boot/zephyr/include/flash_map_backend/flash_map_backend.h
+++ b/boot/zephyr/include/flash_map_backend/flash_map_backend.h
@@ -52,6 +52,14 @@ int flash_device_base(uint8_t fd_id, uintptr_t *ret);
 
 int flash_area_id_from_image_slot(int slot);
 
+/**
+ * Converts the specified flash area ID to an image slot index.
+ *
+ * Returns image slot index (0 or 1), or -1 if ID doesn't correspond to an image
+ * slot.
+ */
+int flash_area_id_to_image_slot(int area_id);
+
 /* Retrieve the flash sector a given offset belongs to.
  *
  * Returns 0 on success, or an error code on failure.

--- a/sim/mcuboot-sys/csupport/run.c
+++ b/sim/mcuboot-sys/csupport/run.c
@@ -384,6 +384,19 @@ int flash_area_get_sectors(int fa_id, uint32_t *count,
     return 0;
 }
 
+int flash_area_id_to_image_slot(int area_id)
+{
+    switch (area_id) {
+    case FLASH_AREA_IMAGE_PRIMARY:
+        return 0;
+    case FLASH_AREA_IMAGE_SECONDARY:
+        return 1;
+    default:
+        printf("Unsupported image area ID\n");
+        abort();
+    }
+}
+
 void sim_assert(int x, const char *assertion, const char *file, unsigned int line, const char *function)
 {
     if (!(x)) {


### PR DESCRIPTION
enc_state table was indexed with assumption that
image flash area are subsequent and increasing numbers.
It might not be true while building zephyr.

Patch introduce flash_area_id_to_image_slot() implementation for
the zephyr port and uses it to assign proper slot number.
This API is already available in MyNewt.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>