### PR TITLE
Use Mynewt pkgpath in imports

### DIFF
--- a/ci/mynewt_run.sh
+++ b/ci/mynewt_run.sh
@@ -20,10 +20,7 @@
 export PATH=$HOME/bin:$PATH
 pwd
 
-ln -s ci/mynewt_targets targets
-ln -s ci/mynewt_keys keys
-
-for target in $(ls targets); do
+for target in $(ls ci/mynewt_targets); do
     newt build $target
     [[ $? -ne 0 ]] && exit 1
 done

--- a/ci/mynewt_targets/bootserial/syscfg.yml
+++ b/ci/mynewt_targets/bootserial/syscfg.yml
@@ -17,7 +17,7 @@
 #
 
 $import:
-    - 'targets/basic/syscfg.yml'
+    - '@mcuboot/ci/mynewt_targets/basic/syscfg.yml'
 
 syscfg.vals:
     BOOT_SERIAL: 1

--- a/ci/mynewt_targets/ecdsa/syscfg.yml
+++ b/ci/mynewt_targets/ecdsa/syscfg.yml
@@ -17,7 +17,7 @@
 #
 
 $import:
-    - 'targets/basic/syscfg.yml'
+    - '@mcuboot/ci/mynewt_targets/basic/syscfg.yml'
 
 syscfg.vals:
     BOOTUTIL_VALIDATE_SLOT0: 1

--- a/ci/mynewt_targets/ecdsa_kw/syscfg.yml
+++ b/ci/mynewt_targets/ecdsa_kw/syscfg.yml
@@ -17,7 +17,7 @@
 #
 
 $import:
-    - 'targets/basic/syscfg.yml'
+    - '@mcuboot/ci/mynewt_targets/basic/syscfg.yml'
 
 syscfg.vals:
     BOOTUTIL_VALIDATE_SLOT0: 1

--- a/ci/mynewt_targets/rsa/syscfg.yml
+++ b/ci/mynewt_targets/rsa/syscfg.yml
@@ -17,7 +17,7 @@
 #
 
 $import:
-    - 'targets/basic/syscfg.yml'
+    - '@mcuboot/ci/mynewt_targets/basic/syscfg.yml'
 
 syscfg.vals:
     BOOTUTIL_VALIDATE_SLOT0: 1

--- a/ci/mynewt_targets/rsa_kw/syscfg.yml
+++ b/ci/mynewt_targets/rsa_kw/syscfg.yml
@@ -17,7 +17,7 @@
 #
 
 $import:
-    - 'targets/basic/syscfg.yml'
+    - '@mcuboot/ci/mynewt_targets/basic/syscfg.yml'
 
 syscfg.vals:
     BOOTUTIL_VALIDATE_SLOT0: 1

--- a/ci/mynewt_targets/rsa_overwriteonly/syscfg.yml
+++ b/ci/mynewt_targets/rsa_overwriteonly/syscfg.yml
@@ -17,7 +17,7 @@
 #
 
 $import:
-    - 'targets/basic/syscfg.yml'
+    - '@mcuboot/ci/mynewt_targets/basic/syscfg.yml'
 
 syscfg.vals:
     BOOTUTIL_VALIDATE_SLOT0: 1

--- a/ci/mynewt_targets/rsa_rsaoaep/syscfg.yml
+++ b/ci/mynewt_targets/rsa_rsaoaep/syscfg.yml
@@ -17,7 +17,7 @@
 #
 
 $import:
-    - 'targets/basic/syscfg.yml'
+    - '@mcuboot/ci/mynewt_targets/basic/syscfg.yml'
 
 syscfg.vals:
     BOOTUTIL_VALIDATE_SLOT0: 1

--- a/ci/mynewt_targets/rsa_rsaoaep_bootstrap/syscfg.yml
+++ b/ci/mynewt_targets/rsa_rsaoaep_bootstrap/syscfg.yml
@@ -17,7 +17,7 @@
 #
 
 $import:
-    - 'targets/basic/syscfg.yml'
+    - '@mcuboot/ci/mynewt_targets/basic/syscfg.yml'
 
 syscfg.vals:
     BOOTUTIL_VALIDATE_SLOT0: 1


### PR DESCRIPTION
This allows both MCUBoot as root package with Mynewt core as remote and the other way around.

Currently when MCUBoot is added as a repo with Mynewt as root package, `newt` shows warning messages due to the CI targets having an absolute import path (not a pkgpath) and `newt` not being able to find the imported packages. Support for using pkgpaths in `newt` was added today, https://github.com/apache/mynewt-newt/pull/277, and this updates the imports accordingly. I also removed symlink creation because `newt` is able to find the packages by scanning the source tree.