### PR TITLE
boot: zephyr: fix MCUboot linking after DT/Kconfig changes

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -13,17 +13,15 @@ config MCUBOOT
 	bool
 	select MPU_ALLOW_FLASH_WRITE if ARM_MPU
 
-if BOARD_HAS_NRF5_BOOTLOADER
+# When compiling MCUBoot, ensure to link in the boot partition.
 
-# When compiling MCUBoot, the image will be linked to the boot partition.
-# Override .text offset to make sure it is set to zero.
-# This is necessary when other bootloaders set a different default for
-# application images which are not bootloaders.
+config FLASH_LOAD_OFFSET
+	default $(dt_hex_val,DT_CODE_PARTITION_OFFSET)
 
-config TEXT_SECTION_OFFSET
-	default 0x00
+# Inform the linker of the size of the partition
 
-endif # BOARD_HAS_NRF5_BOOTLOADER
+config FLASH_LOAD_SIZE
+	default $(dt_hex_val,DT_CODE_PARTITION_SIZE)
 
 config BOOT_USE_MBEDTLS
 	bool


### PR DESCRIPTION
Correctly set the KConfig options:
- FLASH_LOAD_OFFSET
- FLASH_LOAD_SIZE

to ensure that MCUboot is linked into the correct partition.
I have another commit to push to Zephyr, to fix an issue specific to `nrf52840_pca10059`.

@nvlsianpu please have a look.