### PR TITLE
dfu: Add support for switching to do USB DFU

### DIFF
--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -67,6 +67,10 @@ if(EXISTS targets/${BOARD}.h)
   zephyr_library_compile_definitions(MCUBOOT_TARGET_CONFIG="${BOARD}.h")
 endif()
 
+if(EXISTS ${BOOT_DIR}/zephyr/targets/${BOARD}.c)
+  zephyr_sources(${BOOT_DIR}/zephyr/targets/${BOARD}.c)
+endif()
+
 # Zephyr port-specific sources.
 zephyr_library_sources(
   main.c

--- a/boot/zephyr/include/usb_dfu/usb_dfu.h
+++ b/boot/zephyr/include/usb_dfu/usb_dfu.h
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2019 Atmark Techno, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+int is_entering_usb_dfu(void);

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -42,6 +42,7 @@ const struct boot_uart_funcs boot_funcs = {
 
 #ifdef CONFIG_BOOT_WAIT_FOR_USB_DFU
 #include <usb/class/usb_dfu.h>
+#include "usb_dfu/usb_dfu.h"
 #endif
 
 MCUBOOT_LOG_MODULE_REGISTER(mcuboot);
@@ -202,9 +203,11 @@ void main(void)
 #endif
 
 #ifdef CONFIG_BOOT_WAIT_FOR_USB_DFU
-    BOOT_LOG_INF("Waiting for USB DFU");
-    wait_for_usb_dfu();
-    BOOT_LOG_INF("USB DFU wait time elapsed");
+    if (is_entering_usb_dfu()) {
+        BOOT_LOG_INF("Waiting for USB DFU");
+        wait_for_usb_dfu();
+        BOOT_LOG_INF("USB DFU wait time elapsed");
+    }
 #endif
 
     rc = boot_go(&rsp);

--- a/boot/zephyr/targets/intel_s1000_crb.c
+++ b/boot/zephyr/targets/intel_s1000_crb.c
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2019 Atmark Techno, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+int is_entering_usb_dfu(void)
+{
+	/* Nothing to do */
+	return 1;
+}


### PR DESCRIPTION
Sometimes, we'd like to switch whether to do USB DFU or not
by like button or something else.
This commit supports these cases.

intel_s1000_crb has nothing to do so it returns just 1.