### PR TITLE
Mynewt: Fix boot_serial unit tests

### DIFF
--- a/boot/boot_serial/test/pkg.yml
+++ b/boot/boot_serial/test/pkg.yml
@@ -30,3 +30,6 @@ pkg.deps:
 
 pkg.deps.SELFTEST:
     - "@apache-mynewt-core/sys/console/stub"
+
+pkg.cflags:
+    - '-DMCUBOOT_MYNEWT'

--- a/boot/boot_serial/test/src/boot_test.h
+++ b/boot/boot_serial/test/src/boot_test.h
@@ -33,11 +33,12 @@
 #include "testutil/testutil.h"
 #include "hal/hal_flash.h"
 #include "flash_map_backend/flash_map_backend.h"
+#include "bootutil/bootutil.h"
 
 #include "boot_serial_priv.h"
 
 #ifdef __cplusplus
-#extern "C" {
+extern "C" {
 #endif
 
 void tx_msg(void *src, int len);

--- a/boot/bootutil/include/bootutil/bootutil.h
+++ b/boot/bootutil/include/bootutil/bootutil.h
@@ -26,6 +26,11 @@
 extern "C" {
 #endif
 
+#if defined(MCUBOOT_MYNEWT)
+#define FLASH_AREA_IMAGE_PRIMARY    FLASH_AREA_IMAGE_0
+#define FLASH_AREA_IMAGE_SECONDARY  FLASH_AREA_IMAGE_1
+#endif
+
 /** Attempt to boot the contents of the primary slot. */
 #define BOOT_SWAP_TYPE_NONE     1
 

--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -24,6 +24,7 @@
 
 #include <flash_map_backend/flash_map_backend.h>
 
+#include "bootutil/bootutil.h"
 #include "bootutil/image.h"
 #include "mcuboot_config/mcuboot_config.h"
 
@@ -144,11 +145,6 @@ struct boot_swap_state {
 
 #define BOOT_FLAG_IMAGE_OK              0
 #define BOOT_FLAG_COPY_DONE             1
-
-#if defined(MCUBOOT_MYNEWT)
-    #define FLASH_AREA_IMAGE_PRIMARY    FLASH_AREA_IMAGE_0
-    #define FLASH_AREA_IMAGE_SECONDARY  FLASH_AREA_IMAGE_1
-#endif
 
 extern const uint32_t BOOT_MAGIC_SZ;
 

--- a/boot/bootutil/test/pkg.yml
+++ b/boot/bootutil/test/pkg.yml
@@ -28,3 +28,4 @@ pkg.deps:
 
 pkg.deps.SELFTEST:
     - "@apache-mynewt-core/sys/console/stub"
+    - "@apache-mynewt-core/sys/log/stub"


### PR DESCRIPTION
These unit tests were failing with build errors such as this:

```
boot/boot_serial/test/src/testcases/boot_serial_img_msg.c:64:26: error: use of undeclared identifier 'FLASH_AREA_IMAGE_PRIMARY'
    rc = flash_area_open(FLASH_AREA_IMAGE_PRIMARY, &fap);
                             ^
```

The `FLASH_AREA_IMAGE_{PRIMARY,SECONDARY}` definitions were not visible because `MCUBOOT_MYNEWT` was not getting defined in the boot_serial unit test package.

This commit defines `MCUBOOT_MYNEWT` in the boot_serial unit test package, and adds the necessary include to pull in the PRIMARY / SECONDARY definitions.
