### PR TITLE
Add use and documentation of west manifest to mcuboot

### DIFF
--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -66,8 +66,6 @@ set(NRF_DIR "${MCUBOOT_DIR}/ext/nrf")
 if(CONFIG_BOOT_USE_NRF_CC310_BL)
 set(NRFXLIB_DIR ${MCUBOOT_DIR}/../nrfxlib)
 assert_exists(NRFXLIB_DIR)
-# Don't include this if we are using west
- add_subdirectory(${NRFXLIB_DIR} ${PROJECT_BINARY_DIR}/nrfxlib)
 endif()
 
 zephyr_library_include_directories(

--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -84,6 +84,7 @@ config BOOT_SIGNATURE_TYPE_ECDSA_P256
 if BOOT_SIGNATURE_TYPE_ECDSA_P256
 choice
 	prompt "Ecdsa implementation"
+	default BOOT_CC310 if HAS_HW_NRF_CC310
 	default BOOT_TINYCRYPT
 config BOOT_TINYCRYPT
 	bool "Use tinycrypt"

--- a/ext/nrf/README.md
+++ b/ext/nrf/README.md
@@ -2,7 +2,20 @@
 
 ## Pre-prerequisites
 
-Clone [nrfxlib](https://github.com/NordicPlayground/nrfxlib) next to the mcuboot root folder. So that it's located `../nrfxlib` from mcuboots root folder.
+Install west from Zephyr's pip package. This requires Python 3 or greater. 
+```
+pip install --user west
+```
+
+Go outside the root folder and clone the [nRF Connect SDK](https://github.com/NordicPlayground/fw-nrfconnect-nrf) next to the mcuboot folder.
+
+```
+git clone https://github.com/NordicPlayground/fw-nrfconnect-nrf nrf
+west init -l nrf 
+west update
+```
+
+The reason this is done this way is to get the `nrfxlib` and having west discover it as a module in Zephyr's build system.
 
 ## Building
 


### PR DESCRIPTION
This PR will add a west manifest and remove unused symbols used for building cc310 support for nRF52840 in MCUBoot. Now mcuboot can use west to initialize zephyr it can also use revisions in the manifest to lock the support to a specific revision of zephyr.