### PR TITLE
boot: zephyr: do not override TEXT_SECTION_OFFSET

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -14,18 +14,6 @@ config MCUBOOT
 	select MPU_ALLOW_FLASH_WRITE if ARM_MPU
 	select USE_CODE_PARTITION if HAS_FLASH_LOAD_OFFSET
 
-if BOARD_HAS_NRF5_BOOTLOADER
-
-# When compiling MCUBoot, the image will be linked to the boot partition.
-# Override .text offset to make sure it is set to zero.
-# This is necessary when other bootloaders set a different default for
-# application images which are not bootloaders.
-
-config TEXT_SECTION_OFFSET
-	default 0x00
-
-endif # BOARD_HAS_NRF5_BOOTLOADER
-
 config BOOT_USE_MBEDTLS
 	bool
 	# Hidden option


### PR DESCRIPTION
It is no longer necessary to override TEXT_SECTION_OFFSET when BOARD_HAS_NRF5_BOOTLOADER. The nrf52840_pca10059 board no longer overrides TEXT_SECTION_OFFSET but sets the correct FLASH_LOAD_OFFSET instead, automatically.

Please @nvlsianpu, have a look.