### PR TITLE
cmake: Fix bug where dts.overlay was not being appended

### DIFF
--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -16,14 +16,18 @@ set(BOARD qemu_x86)
 # the list).
 if(DTC_OVERLAY_FILE)
   set(DTC_OVERLAY_FILE
-      "${DTC_OVERLAY_FILE} ${CMAKE_CURRENT_LIST_DIR}/dts.overlay")
+    "${DTC_OVERLAY_FILE} ${CMAKE_CURRENT_LIST_DIR}/dts.overlay"
+    CACHE STRING "" FORCE
+    )
 else()
   set(DTC_OVERLAY_FILE ${CMAKE_CURRENT_LIST_DIR}/dts.overlay)
 endif()
 
 if (EXISTS ${CMAKE_CURRENT_LIST_DIR}/boards/${BOARD}.overlay)
   set(DTC_OVERLAY_FILE
-      "${DTC_OVERLAY_FILE} ${CMAKE_CURRENT_LIST_DIR}/boards/${BOARD}.overlay")
+    "${DTC_OVERLAY_FILE} ${CMAKE_CURRENT_LIST_DIR}/boards/${BOARD}.overlay"
+    CACHE STRING "" FORCE
+    )
 endif()
 
 # Enable Zephyr runner options which request mass erase if so


### PR DESCRIPTION
This fixes #399 where dts.overlay was not being appended.

The build scripts were erroneously modifying the shadowed non-cache
variable instead of the cache variable.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>