### PR TITLE
zephyr: remove BOOT_HAVE_LOGGING Kconfig option

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -170,22 +170,9 @@ config ZEPHYR_TRY_MASS_ERASE
 
 	  This is not available for all targets.
 
-config BOOT_HAVE_LOGGING
-	bool "MCUboot have logging enabled"
-	default y
-	select LOG
-	select LOG_IMMEDIATE
-	help
-	  If y, enables logging on the serial port. The log level can
-	  be defined by setting `CONFIG_MCUBOOT_LOG_LEVEL_*`.
-	  If unsure, leave at the default value.
-
-if BOOT_HAVE_LOGGING
 module = MCUBOOT
-module-dep = LOG
-module-str = Log level for MCUBOOT application
+module-str = MCUBoot bootloader
 source "subsys/logging/Kconfig.template.log_config"
-endif
 
 menuconfig MCUBOOT_SERIAL
 	bool "MCUboot serial recovery"

--- a/boot/zephyr/prj.conf
+++ b/boot/zephyr/prj.conf
@@ -39,5 +39,7 @@ CONFIG_MULTITHREADING=n
 # CONFIG_BT_CTLR is not set
 # CONFIG_I2C is not set
 
+CONFIG_LOG=y
+CONFIG_LOG_IMMEDIATE=y
 ### Ensure Zephyr logging changes don't use more resources
 CONFIG_LOG_DEFAULT_LEVEL=0


### PR DESCRIPTION
At present setting up Zephyr logging subsystem is performed in a non-standard and somehow confusing way. Rather than defining a log module and a corresponding log level the MCUBoot uses  BOOT_HAVE_LOGGING Kconfig option.

The standard method to configure logging in Zephyr looks as follows:
- enable log subsystem by selecting `LOG` Kconfig option.
- select module log level by modifying `MCUBOOT_LOG_LEVEL`

The current MCUBoot method:
- enable `BOOT_HAVE_LOGGING` Kconfig option (the option selects `LOG`).
- select module log level by modifying `MCUBOOT_LOG_LEVEL`

Presumably the design comes from the time when Zephyr used two different log subsystems and user might have had a problem selecting the proper one. A dedicated BOOT_HAVE_LOGGING would simplify it. This is no longer necessary. Additionally the current design makes it difficult to turn off logging. Deselecting BOOT_HAVE_LOGGING leaves `LOG` enabled and the whole log subsystem is still compiled and linked in.

This commit removes the non-standard BOOT_HAVE_LOGGING Kconfig option.