### PR TITLE
zephyr: fix logging

### DIFF
--- a/boot/zephyr/boards/nrf51_pca10028.conf
+++ b/boot/zephyr/boards/nrf51_pca10028.conf
@@ -1,5 +1,6 @@
-# Due the small boot partition can't use logging and debug optimalization
-# out-off-the-box. For using these features need to increase boot partition via
-# zephyr DTS.
-CONFIG_BOOT_HAVE_LOGGING=n
+# Due the small boot partition, we can't enable logging or the debug
+# optimization level out off the box. You need to increase the boot
+# partition size with a zephyr DTS overlay to make MCUboot's debug
+# builds fit.
+CONFIG_LOG=n
 CONFIG_SIZE_OPTIMIZATIONS=y

--- a/boot/zephyr/boards/nrf52840_pca10059.conf
+++ b/boot/zephyr/boards/nrf52840_pca10059.conf
@@ -1,7 +1,7 @@
 # The UART is used for Serial Recovery, so logging requires
 # an RTT console, which is not available out of the box on this board.
 # Disable logging.
-CONFIG_BOOT_HAVE_LOGGING=n
+CONFIG_LOG=n
 
 # Serial
 CONFIG_SERIAL=y

--- a/boot/zephyr/include/mcuboot_config/mcuboot_config.h
+++ b/boot/zephyr/include/mcuboot_config/mcuboot_config.h
@@ -44,7 +44,7 @@
 #define MCUBOOT_OVERWRITE_ONLY_FAST
 #endif
 
-#ifdef CONFIG_BOOT_HAVE_LOGGING
+#ifdef CONFIG_LOG
 #define MCUBOOT_HAVE_LOGGING 1
 #endif
 


### PR DESCRIPTION
The removal of CONFIG_BOOT_HAVE_LOGGING in 15aa6ef ("zephyr: remove BOOT_HAVE_LOGGING Kconfig option") missed some uses. In particular, the one in mcuboot_config.h that converts Kconfig options to MCUboot's platform-agnostic configuration macros.

This broke logging even when the relevant Kconfig options were on.

Fix things up by using CONFIG_LOG instead.

Tested logging works again on nrf52840_pca10056. Build tested nrf51_pca10056 to make sure it still fits. The nrf52840_pca10059 build overflows flash by 0.16%, but that was a problem before 15aa6ef.

@nvlsianpu I think we should fix the nrf52840_pca10059 build break in a separate patch if it's OK with you. This PR is just to fix the logging regression.