### PR TITLE
zephyr: fix build for nrf52840_pca10059

### DIFF
--- a/boot/zephyr/boards/nrf52840_pca10059.conf
+++ b/boot/zephyr/boards/nrf52840_pca10059.conf
@@ -3,6 +3,10 @@
 # Disable logging.
 CONFIG_LOG=n
 
+# The build won't fit on the partition allocated for it without size
+# optimizations.
+CONFIG_SIZE_OPTIMIZATIONS=y
+
 # Serial
 CONFIG_SERIAL=y
 CONFIG_UART_NRFX=y


### PR DESCRIPTION
I can get the board enumerating as a CDC-ACM device when plugged into my system with this patch. Without it, it overflows flash with the toolchain Nordic is currently recommending.

CC: @lemrey 