### PR TITLE
boot: bootutil: Change conditional to valid C

### DIFF
--- a/boot/bootutil/include/bootutil/sha256.h
+++ b/boot/bootutil/include/bootutil/sha256.h
@@ -31,10 +31,9 @@
 
 #include "mcuboot_config/mcuboot_config.h"
 
-#define NUM_CRYPTO_BACKENDS (defined(MCUBOOT_USE_MBED_TLS) +\
-			     defined(MCUBOOT_USE_TINYCRYPT) +\
-			     defined(MCUBOOT_USE_CC310))
-#if NUM_CRYPTO_BACKENDS != 1
+#if (defined(MCUBOOT_USE_MBED_TLS) + \
+     defined(MCUBOOT_USE_TINYCRYPT) + \
+     defined(MCUBOOT_USE_CC310)) != 1
     #error "One crypto backend must be defined either CC310, MBED_TLS or TINYCRYPT"
 #endif
 


### PR DESCRIPTION
The change

    boot: bootutil: Simplify check for crypto backends to reduce complexity

    Adding multiple crypto backends will grow quadraticly. This change will
    ensure that the growth will be linear and generate less complexity.

unfortunately is not legal C.  It can be fixed by eliminating the
intermediate macro, so that the `defined` keywords are within the `#if`.

Signed-off-by: David Brown <david.brown@linaro.org>