### PR TITLE
Add pkgpath to Mynewt key_files

### DIFF
--- a/ci/mynewt_targets/ecdsa/target.yml
+++ b/ci/mynewt_targets/ecdsa/target.yml
@@ -20,4 +20,4 @@
 target.app: "@mcuboot/boot/mynewt"
 target.bsp: "@apache-mynewt-core/hw/bsp/nordic_pca10056"
 target.build_profile: "optimized"
-target.key_file: "root-ec-p256.pem"
+target.key_file: "@mcuboot/root-ec-p256.pem"

--- a/ci/mynewt_targets/ecdsa_kw/target.yml
+++ b/ci/mynewt_targets/ecdsa_kw/target.yml
@@ -20,4 +20,4 @@
 target.app: "@mcuboot/boot/mynewt"
 target.bsp: "@apache-mynewt-core/hw/bsp/nordic_pca10056"
 target.build_profile: "optimized"
-target.key_file: "root-ec-p256.pem"
+target.key_file: "@mcuboot/root-ec-p256.pem"

--- a/ci/mynewt_targets/rsa/target.yml
+++ b/ci/mynewt_targets/rsa/target.yml
@@ -20,4 +20,4 @@
 target.app: "@mcuboot/boot/mynewt"
 target.bsp: "@apache-mynewt-core/hw/bsp/nordic_pca10056"
 target.build_profile: "optimized"
-target.key_file: "root-rsa-2048.pem"
+target.key_file: "@mcuboot/root-rsa-2048.pem"

--- a/ci/mynewt_targets/rsa_kw/target.yml
+++ b/ci/mynewt_targets/rsa_kw/target.yml
@@ -20,4 +20,4 @@
 target.app: "@mcuboot/boot/mynewt"
 target.bsp: "@apache-mynewt-core/hw/bsp/nordic_pca10056"
 target.build_profile: "optimized"
-target.key_file: "root-rsa-2048.pem"
+target.key_file: "@mcuboot/root-rsa-2048.pem"

--- a/ci/mynewt_targets/rsa_overwriteonly/target.yml
+++ b/ci/mynewt_targets/rsa_overwriteonly/target.yml
@@ -20,4 +20,4 @@
 target.app: "@mcuboot/boot/mynewt"
 target.bsp: "@apache-mynewt-core/hw/bsp/nordic_pca10056"
 target.build_profile: "optimized"
-target.key_file: "root-rsa-2048.pem"
+target.key_file: "@mcuboot/root-rsa-2048.pem"

--- a/ci/mynewt_targets/rsa_rsaoaep/target.yml
+++ b/ci/mynewt_targets/rsa_rsaoaep/target.yml
@@ -20,4 +20,4 @@
 target.app: "@mcuboot/boot/mynewt"
 target.bsp: "@apache-mynewt-core/hw/bsp/nordic_pca10056"
 target.build_profile: "optimized"
-target.key_file: "root-rsa-2048.pem"
+target.key_file: "@mcuboot/root-rsa-2048.pem"

--- a/ci/mynewt_targets/rsa_rsaoaep_bootstrap/target.yml
+++ b/ci/mynewt_targets/rsa_rsaoaep_bootstrap/target.yml
@@ -20,4 +20,4 @@
 target.app: "@mcuboot/boot/mynewt"
 target.bsp: "@apache-mynewt-core/hw/bsp/nordic_pca10056"
 target.build_profile: "optimized"
-target.key_file: "root-rsa-2048.pem"
+target.key_file: "@mcuboot/root-rsa-2048.pem"


### PR DESCRIPTION
This allows the CI targets to be built if MCUBoot is a dependency of other repos as well as current local package only build support.