### PR TITLE
[SIM] Relax trailer verification for multi-image

### DIFF
--- a/sim/src/image.rs
+++ b/sim/src/image.rs
@@ -943,12 +943,12 @@ impl Images {
                        magic: Option<u8>, image_ok: Option<u8>,
                        copy_done: Option<u8>) -> bool {
         for image in &self.images {
-            if !verify_trailer(flash, &image.slots, slot,
+            if verify_trailer(flash, &image.slots, slot,
                                magic, image_ok, copy_done) {
-                return false;
+                return true;
             }
         }
-        true
+        false
     }
 
     /// Mark each of the images for permanent upgrade.


### PR DESCRIPTION
The simulator does trailer verification to ensure the status is what would be expected when operating a swap. When doing a multi-image swap upgrade one of the images must be in a known status but others might not be, depending on which image number is being upgraded at the moment. This patch relaxes the verification to assure at least one is in a known status.