### PR TITLE
boot: serial recovery: Add pca10090 default detect pin

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -222,6 +222,7 @@ config BOOT_SERIAL_DETECT_PORT
 
 config BOOT_SERIAL_DETECT_PIN
 	int "Pin to trigger serial recovery mode"
+	default 6 if BOARD_NRF9160_PCA10090
 	default 11 if BOARD_NRF52840_PCA10056
 	default 13 if BOARD_NRF52_PCA10040
 	help


### PR DESCRIPTION
Add button 1 as default serial detect pin for nrf9160_pca10090

Signed-off-by: Andreas Vibeto <andreas.vibeto@nordicsemi.no>