### PR TITLE
Add watchdog feeding macro

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -954,6 +954,8 @@ boot_copy_sector(const struct flash_area *fap_src,
         }
 
         bytes_copied += chunk_sz;
+
+        MCUBOOT_WATCHDOG_FEED();
     }
 
     return 0;

--- a/boot/mynewt/mcuboot_config/include/mcuboot_config/mcuboot_config.h
+++ b/boot/mynewt/mcuboot_config/include/mcuboot_config/mcuboot_config.h
@@ -73,4 +73,14 @@
 
 #define MCUBOOT_MAX_IMG_SECTORS       MYNEWT_VAL(BOOTUTIL_MAX_IMG_SECTORS)
 
+#if MYNEWT_VAL(WATCHDOG_INTERVAL)
+#include <hal/hal_watchdog.h>
+#define MCUBOOT_WATCHDOG_FEED()    \
+    do {                           \
+        hal_watchdog_tickle();     \
+    } while (0)
+#else
+#define MCUBOOT_WATCHDOG_FEED()    do {} while (0)
+#endif
+
 #endif /* __MCUBOOT_CONFIG_H__ */

--- a/boot/zephyr/include/mcuboot_config/mcuboot_config.h
+++ b/boot/zephyr/include/mcuboot_config/mcuboot_config.h
@@ -78,4 +78,9 @@
 
 #endif /* !__BOOTSIM__ */
 
+#define MCUBOOT_WATCHDOG_FEED()         \
+    do {                                \
+        /* TODO: to be implemented */   \
+    } while (0)
+
 #endif /* __MCUBOOT_CONFIG_H__ */

--- a/samples/mcuboot_config/mcuboot_config.template.h
+++ b/samples/mcuboot_config/mcuboot_config.template.h
@@ -116,4 +116,17 @@
  * "assert" is used. */
 /* #define MCUBOOT_HAVE_ASSERT_H */
 
+/*
+ * Watchdog feeding
+ */
+
+/* This macro might be implemented if the OS / HW watchdog is enabled while
+ * doing a swap upgrade and the time it takes for a swapping is long enough
+ * to cause an unwanted reset. If implementing this, the OS main.c must also
+ * enable the watchdog (if required)!
+ *
+ * #define MCUBOOT_WATCHDOG_FEED()
+ *    do { do watchdog feeding here! } while (0)
+ */
+
 #endif /* __MCUBOOT_CONFIG_H__ */


### PR DESCRIPTION
When HW / OS provides an always enabled watchdog, this macro can optionally be implemented to avoid resets which are expected to occur under normal conditions when swapping very large images or
running on slower devices.