### PR TITLE
bugfix: disable usb for all usb funcs before booting

### DIFF
--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -75,7 +75,7 @@ static void do_boot(struct boot_rsp *rsp)
                                      rsp->br_hdr->ih_hdr_size);
     irq_lock();
     sys_clock_disable();
-#ifdef CONFIG_BOOT_SERIAL_CDC_ACM
+#ifdef CONFIG_USB
     /* Disable the USB to prevent it from firing interrupts */
     usb_disable();
 #endif


### PR DESCRIPTION
USB should be disabled before jumping to the application image if any usb func is enabled to support using either `MCUBOOT_SERIAL` plus `BOOT_SERIAL_CDC_ACM`  or DFU mode with `BOOT_WAIT_FOR_USB_DFU`, or any future usb functionality which could be involved in MCUboot. 

Actually, this fix can't fix the issue #477 totally because `usb_disable()` is not implemented in STM32 SoCs. But this one is also necessary for fixing the issue. 

fix #477

Signed-off-by: Jun Li <jun.r.li@intel.com>