### PR TITLE
Fix interrupted revert

### DIFF
--- a/sim/src/image.rs
+++ b/sim/src/image.rs
@@ -141,8 +141,8 @@ impl ImagesBuilder {
     pub fn make_no_upgrade_image(self) -> Images {
         let mut flash = self.flash;
         let images = self.slots.into_iter().map(|slots| {
-            let primaries = install_image(&mut flash, &slots, 0, 32784, false);
-            let upgrades = install_image(&mut flash, &slots, 1, 41928, false);
+            let primaries = install_image(&mut flash, &slots, 0, 42784, false);
+            let upgrades = install_image(&mut flash, &slots, 1, 46928, false);
             OneImage {
                 slots: slots,
                 primaries: primaries,


### PR DESCRIPTION
This extends the test+revert case to also force interruptions on revert. Previously only the test stage was interrupted, and this oversight on testing has masked an issue where the revert swapping is not resilient to failures, causing an extra swap after it has finished, ending up with the test image as confirmed in the primary slot and the old image in the secondary slot.

It might be related to #480, although the issue that is being tackled here does not end in a revert forever loop.