### PR TITLE
Fix double swap on interrupted revert

### DIFF
--- a/boot/bootutil/include/bootutil/bootutil.h
+++ b/boot/bootutil/include/bootutil/bootutil.h
@@ -79,10 +79,12 @@ struct boot_rsp {
  * when attempting to read/write a trailer.
  */
 struct image_trailer {
-    uint8_t copy_done;
+    uint8_t swap_type;
     uint8_t pad1[MAX_FLASH_ALIGN - 1];
-    uint8_t image_ok;
+    uint8_t copy_done;
     uint8_t pad2[MAX_FLASH_ALIGN - 1];
+    uint8_t image_ok;
+    uint8_t pad3[MAX_FLASH_ALIGN - 1];
     uint8_t magic[16];
 };
 

--- a/boot/bootutil/src/bootutil_misc.c
+++ b/boot/bootutil/src/bootutil_misc.c
@@ -394,6 +394,8 @@ boot_write_magic(const struct flash_area *fap)
 
     off = boot_magic_off(fap);
 
+    BOOT_LOG_DBG("writing magic; fa_id=%d off=0x%x (0x%x)",
+                 fap->fa_id, off, fap->fa_off + off);
     rc = flash_area_write(fap, off, boot_img_magic, BOOT_MAGIC_SZ);
     if (rc != 0) {
         return BOOT_EFLASH;
@@ -414,9 +416,13 @@ boot_write_flag(int flag, const struct flash_area *fap)
     switch (flag) {
     case BOOT_FLAG_COPY_DONE:
         off = boot_copy_done_off(fap);
+        BOOT_LOG_DBG("writing copy_done; fa_id=%d off=0x%x (0x%x)",
+                     fap->fa_id, off, fap->fa_off + off);
         break;
     case BOOT_FLAG_IMAGE_OK:
         off = boot_image_ok_off(fap);
+        BOOT_LOG_DBG("writing image_ok; fa_id=%d off=0x%x (0x%x)",
+                     fap->fa_id, off, fap->fa_off + off);
         break;
     default:
         return BOOT_EBADARGS;
@@ -466,6 +472,9 @@ boot_write_swap_size(const struct flash_area *fap, uint32_t swap_size)
     erased_val = flash_area_erased_val(fap);
     memset(buf, erased_val, BOOT_MAX_ALIGN);
     memcpy(buf, (uint8_t *)&swap_size, sizeof swap_size);
+
+    BOOT_LOG_DBG("writing swap_size; fa_id=%d off=0x%x (0x%x)",
+                 fap->fa_id, off, fap->fa_off + off);
 
     rc = flash_area_write(fap, off, buf, align);
     if (rc != 0) {

--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -180,7 +180,7 @@ struct boot_loader_state {
 int bootutil_verify_sig(uint8_t *hash, uint32_t hlen, uint8_t *sig,
                         size_t slen, uint8_t key_id);
 
-uint32_t boot_slots_trailer_sz(uint8_t min_write_sz);
+uint32_t boot_trailer_sz(uint8_t min_write_sz);
 int boot_status_entries(const struct flash_area *fap);
 uint32_t boot_status_off(const struct flash_area *fap);
 int boot_read_swap_state(const struct flash_area *fap,

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -1026,7 +1026,7 @@ boot_erase_trailer_sectors(const struct flash_area *fap)
 
     /* delete starting from last sector and moving to beginning */
     sector = boot_img_num_sectors(&boot_data, slot) - 1;
-    trailer_sz = boot_slots_trailer_sz(BOOT_WRITE_SZ(&boot_data));
+    trailer_sz = boot_trailer_sz(BOOT_WRITE_SZ(&boot_data));
     total_sz = 0;
     do {
         sz = boot_img_sector_size(&boot_data, slot, sector);
@@ -1072,7 +1072,7 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_status *bs)
     img_off = boot_img_sector_off(&boot_data, BOOT_PRIMARY_SLOT, idx);
 
     copy_sz = sz;
-    trailer_sz = boot_slots_trailer_sz(BOOT_WRITE_SZ(&boot_data));
+    trailer_sz = boot_trailer_sz(BOOT_WRITE_SZ(&boot_data));
 
     /* sz in this function is always sized on a multiple of the sector size.
      * The check against the start offset of the last sector

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -975,6 +975,8 @@ boot_status_init(const struct flash_area *fap, const struct boot_status *bs)
     struct boot_swap_state swap_state;
     int rc;
 
+    BOOT_LOG_DBG("initializing status; fa_id=%d", fap->fa_id);
+
     rc = boot_read_swap_state_by_id(FLASH_AREA_IMAGE_SECONDARY, &swap_state);
     assert(rc == 0);
 
@@ -1012,6 +1014,8 @@ boot_erase_trailer_sectors(const struct flash_area *fap)
     uint32_t off;
     uint32_t sz;
     int rc;
+
+    BOOT_LOG_DBG("erasing trailer; fa_id=%d", fap->fa_id);
 
     switch (fap->fa_id) {
     case FLASH_AREA_IMAGE_PRIMARY:
@@ -1101,6 +1105,7 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_status *bs)
     assert (rc == 0);
 
     if (bs->state == BOOT_STATUS_STATE_0) {
+        BOOT_LOG_DBG("erasing scratch area");
         rc = boot_erase_sector(fap_scratch, 0, sz);
         assert(rc == 0);
 
@@ -1289,6 +1294,7 @@ boot_copy_image(struct boot_status *bs)
      * image is written without a trailer as is the case when using newt, the
      * trailer that was left might trigger a new upgrade.
      */
+    BOOT_LOG_DBG("erasing secondary header");
     rc = boot_erase_sector(fap_secondary_slot,
                            boot_img_sector_off(&boot_data,
                                    BOOT_SECONDARY_SLOT, 0),
@@ -1296,6 +1302,7 @@ boot_copy_image(struct boot_status *bs)
                                    BOOT_SECONDARY_SLOT, 0));
     assert(rc == 0);
     last_sector = boot_img_num_sectors(&boot_data, BOOT_SECONDARY_SLOT) - 1;
+    BOOT_LOG_DBG("erasing secondary trailer");
     rc = boot_erase_sector(fap_secondary_slot,
                            boot_img_sector_off(&boot_data,
                                    BOOT_SECONDARY_SLOT, last_sector),
@@ -1481,7 +1488,8 @@ boot_swap_image(struct boot_status *bs)
 
 #ifdef MCUBOOT_VALIDATE_PRIMARY_SLOT
     if (boot_status_fails > 0) {
-        BOOT_LOG_WRN("%d status write fails performing the swap", boot_status_fails);
+        BOOT_LOG_WRN("%d status write fails performing the swap",
+                     boot_status_fails);
     }
 #endif
 

--- a/sim/mcuboot-sys/src/c.rs
+++ b/sim/mcuboot-sys/src/c.rs
@@ -41,7 +41,7 @@ pub fn boot_go(multiflash: &mut SimMultiFlash, areadesc: &AreaDesc,
 }
 
 pub fn boot_trailer_sz(align: u8) -> u32 {
-    unsafe { raw::boot_slots_trailer_sz(align) }
+    unsafe { raw::boot_trailer_sz(align) }
 }
 
 pub fn boot_magic_sz() -> usize {
@@ -87,7 +87,7 @@ mod raw {
         pub static mut c_asserts: u8;
         pub static mut c_catch_asserts: u8;
 
-        pub fn boot_slots_trailer_sz(min_write_sz: u8) -> u32;
+        pub fn boot_trailer_sz(min_write_sz: u8) -> u32;
 
         pub static BOOT_MAGIC_SZ: u32;
         pub static BOOT_MAX_ALIGN: u32;

--- a/sim/src/image.rs
+++ b/sim/src/image.rs
@@ -824,7 +824,7 @@ impl Images {
         let mut counter = stop;
         let (x, _) = c::boot_go(&mut flash, &self.areadesc, Some(&mut counter), false);
         if x != -0x13579 {
-            warn!("Should have stopped at interruption point");
+            warn!("Should have stopped test at interruption point");
             fails += 1;
         }
 
@@ -835,7 +835,7 @@ impl Images {
 
         let (x, _) = c::boot_go(&mut flash, &self.areadesc, None, false);
         if x != 0 {
-            warn!("Should have finished upgrade");
+            warn!("Should have finished test upgrade");
             fails += 1;
         }
 
@@ -861,9 +861,16 @@ impl Images {
         }
 
         // Do Revert
+        let mut counter = stop;
+        let (x, _) = c::boot_go(&mut flash, &self.areadesc, Some(&mut counter), false);
+        if x != -0x13579 {
+            warn!("Should have stopped revert at interruption point");
+            fails += 1;
+        }
+
         let (x, _) = c::boot_go(&mut flash, &self.areadesc, None, false);
         if x != 0 {
-            warn!("Should have finished a revert");
+            warn!("Should have finished revert upgrade");
             fails += 1;
         }
 
@@ -877,9 +884,10 @@ impl Images {
                   stop);
             fails += 1;
         }
+
         if !self.verify_trailers(&flash, 0, BOOT_MAGIC_GOOD,
                                  BOOT_FLAG_SET, BOOT_FLAG_SET) {
-            warn!("Mismatched trailer for the secondary slot after revert");
+            warn!("Mismatched trailer for the primary slot after revert");
             fails += 1;
         }
         if !self.verify_trailers(&flash, 1, BOOT_MAGIC_UNSET,
@@ -888,8 +896,24 @@ impl Images {
             fails += 1;
         }
 
+        let (x, _) = c::boot_go(&mut flash, &self.areadesc, None, false);
+        if x != 0 {
+            warn!("Should have finished 3rd boot");
+            fails += 1;
+        }
+
+        if !self.verify_images(&flash, 0, 0) {
+            warn!("Image in the primary slot is invalid on 1st boot after revert");
+            fails += 1;
+        }
+        if !self.verify_images(&flash, 1, 1) {
+            warn!("Image in the secondary slot is invalid on 1st boot after revert");
+            fails += 1;
+        }
+
         fails > 0
     }
+
 
     fn try_random_fails(&self, total_ops: i32, count: usize) -> (SimMultiFlash, Vec<i32>) {
         let mut flash = self.flash.clone();

--- a/sim/src/image.rs
+++ b/sim/src/image.rs
@@ -140,8 +140,8 @@ impl ImagesBuilder {
     pub fn make_no_upgrade_image(self) -> Images {
         let mut flash = self.flash;
         let images = self.slots.into_iter().map(|slots| {
-            let primaries = install_image(&mut flash, &slots, 0, 32784, false);
-            let upgrades = install_image(&mut flash, &slots, 1, 41928, false);
+            let primaries = install_image(&mut flash, &slots, 0, 42784, false);
+            let upgrades = install_image(&mut flash, &slots, 1, 46928, false);
             OneImage {
                 slots: slots,
                 primaries: primaries,


### PR DESCRIPTION
This fixes #480.

When mcuboot rewrites image trailers during a swap, some information is lost.  If a reset occurs before the swap completes, mcuboot may not be able to determine which swap type to resume upon startup.  Specifically, if a "revert" swap gets interupted, mcuboot will perform an extraneous swap on the subsequent boot.  See https://github.com/JuulLabs-OSS/mcuboot/issues/480 for details.

**NOTE:** A different PR (#482) adds unit tests which test this fix.

This PR adds an additional field to the image trailer: `swap-type`.  The new trailer structure is illustrated below:

```
     0                   1                   2                   3
     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
    ~                                                               ~
    ~    Swap status (BOOT_MAX_IMG_SECTORS * min-write-size * 3)    ~
    ~                                                               ~
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
    |                 Encryption key 0 (16 octets) [*]              |
    |                                                               |
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
    |                 Encryption key 1 (16 octets) [*]              |
    |                                                               |
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
    |                      Swap size (4 octets)                     |
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
    |   Swap type   |           0xff padding (7 octets)             |
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
    |   Copy done   |           0xff padding (7 octets)             |
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
    |   Image OK    |           0xff padding (7 octets)             |
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
    |                       MAGIC (16 octets)                       |
    |                                                               |
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+

[*]: Only present if the encryption option is enabled (`MCUBOOT_ENC_IMAGES`).
```

The `swap-type` field contains one of the `BOOT_SWAP_TYPE_[...]` constants.  Every time a trailer is written, this field is written along with it.  When resuming an interrupted swap, mcuboot uses this field alone to determine the type of swap being resumed. For new swap operations (non-resume case), this field is not read at all; instead, mcuboot consults the `boot_swap_tables` array to determine the swap operation to perform (as it did prior to this PR).

Some additional changes were necessary to make all the simulated unit tests pass:

* Before initiating a new swap operation, always write the image trailer to the scratch area.  This step allows mcuboot to persist the `swap-type` field somewhere before erasing the trailer in the primary slot.  If a reset occurs immediately after the erase, mcuboot recovers by using the trailer in the scratch area.

* Related to the above: if the scratch area is being used to hold status bytes (because there are no spare sectors in the primary slot), erase the scratch area immediately after the trailer gets written to the primary slot.  This eliminates ambiguity regarding the location of the current trailer in case a reset occurs shortly afterwards.  
