### PR TITLE
Add new verify command

### DIFF
--- a/scripts/imgtool/keys/ecdsa.py
+++ b/scripts/imgtool/keys/ecdsa.py
@@ -57,6 +57,14 @@ class ECDSA256P1Public(KeyClass):
         # signature.
         return 72
 
+    def verify(self, signature, payload):
+        k = self.key
+        if isinstance(self.key, ec.EllipticCurvePrivateKey):
+            k = self.key.public_key()
+        return k.verify(signature=signature, data=payload,
+                        signature_algorithm=ec.ECDSA(SHA256()))
+
+
 class ECDSA256P1(ECDSA256P1Public):
     """
     Wrapper around an ECDSA private key.

--- a/scripts/imgtool/keys/rsa.py
+++ b/scripts/imgtool/keys/rsa.py
@@ -62,6 +62,14 @@ class RSAPublic(KeyClass):
     def sig_len(self):
         return self.key_size() / 8
 
+    def verify(self, signature, payload):
+        k = self.key
+        if isinstance(self.key, rsa.RSAPrivateKey):
+            k = self.key.public_key()
+        return k.verify(signature=signature, data=payload,
+                        padding=PSS(mgf=MGF1(SHA256()), salt_length=32),
+                        algorithm=SHA256())
+
 
 class RSA(RSAPublic):
     """

--- a/scripts/imgtool/main.py
+++ b/scripts/imgtool/main.py
@@ -19,6 +19,7 @@ import re
 import click
 import getpass
 import imgtool.keys as keys
+import sys
 from imgtool import image
 from imgtool.version import decode_version
 
@@ -96,6 +97,26 @@ def getpub(key, lang):
         key.emit_rust()
     else:
         raise ValueError("BUG: should never get here!")
+
+
+@click.argument('imgfile')
+@click.option('-k', '--key', metavar='filename')
+@click.command(help="Check that signed image can be verified by given key")
+def verify(key, imgfile):
+    key = load_key(key) if key else None
+    ret = image.Image.verify(imgfile, key)
+    if ret == image.VerifyResult.OK:
+        print("Image was correctly validated")
+        return
+    elif ret == image.VerifyResult.INVALID_MAGIC:
+        print("Invalid image magic; is this an MCUboot image?")
+    elif ret == image.VerifyResult.INVALID_MAGIC:
+        print("Invalid TLV info magic; is this an MCUboot image?")
+    elif ret == image.VerifyResult.INVALID_HASH:
+        print("Image has an invalid sha256 digest")
+    elif ret == image.VerifyResult.INVALID_SIGNATURE:
+        print("No signature found for the given key")
+    sys.exit(1)
 
 
 def validate_version(ctx, param, value):
@@ -226,6 +247,7 @@ def imgtool():
 
 imgtool.add_command(keygen)
 imgtool.add_command(getpub)
+imgtool.add_command(verify)
 imgtool.add_command(sign)
 
 


### PR DESCRIPTION
`imgtool verify -k <some-key.(pub|sec)> <img-file>`

Allow imgtool to validate that an image has a valid sha256sum and that it was signed by the supplied key.

This implements #486 