### PR TITLE
[MYNEWT] Allow initialization of HASH when enabled

### DIFF
--- a/boot/mynewt/src/main.c
+++ b/boot/mynewt/src/main.c
@@ -218,7 +218,8 @@ main(void)
     assert(rc == 0);
 #endif
 
-#if defined(MCUBOOT_SERIAL) || defined(MCUBOOT_HAVE_LOGGING) || MYNEWT_VAL(CRYPTO)
+#if defined(MCUBOOT_SERIAL) || defined(MCUBOOT_HAVE_LOGGING) || \
+        MYNEWT_VAL(CRYPTO) || MYNEWT_VAL(HASH)
     /* initialize uart/crypto without os */
     os_dev_initialize_all(OS_DEV_INIT_PRIMARY);
     os_dev_initialize_all(OS_DEV_INIT_SECONDARY);


### PR DESCRIPTION
The Mynewt HASH HW driver can be used to do the sha256 validation in the bootloader instead of relying on mbedTLS/tinycrypt. When enabled it must be initialized before `boot_go` (and `boot_img_validate`) is run, so this does the extra checking and runs initialization when required.

This is related to https://github.com/apache/mynewt-core/pull/1876