### PR TITLE
Update mbedTLS sha256 usage to avoid deprecation

### DIFF
--- a/boot/bootutil/include/bootutil/sha256.h
+++ b/boot/bootutil/include/bootutil/sha256.h
@@ -61,20 +61,20 @@ typedef mbedtls_sha256_context bootutil_sha256_context;
 static inline void bootutil_sha256_init(bootutil_sha256_context *ctx)
 {
     mbedtls_sha256_init(ctx);
-    mbedtls_sha256_starts(ctx, 0);
+    (void)mbedtls_sha256_starts_ret(ctx, 0);
 }
 
 static inline void bootutil_sha256_update(bootutil_sha256_context *ctx,
                                           const void *data,
                                           uint32_t data_len)
 {
-    mbedtls_sha256_update(ctx, data, data_len);
+    (void)mbedtls_sha256_update_ret(ctx, data, data_len);
 }
 
 static inline void bootutil_sha256_finish(bootutil_sha256_context *ctx,
                                           uint8_t *output)
 {
-    mbedtls_sha256_finish(ctx, output);
+    (void)mbedtls_sha256_finish_ret(ctx, output);
 }
 #endif /* MCUBOOT_USE_MBED_TLS */
 


### PR DESCRIPTION
mbedTLS made sha256 functions that do not return errors deprecated. This updates to use the new functions avoiding the extra functions calls, and breakage when the deprecated calls are effectively removed.