### PR TITLE
requirements.txt: bump cryptography Py package version

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,3 +1,3 @@
-cryptography
+cryptography>=2.6
 intelhex
 click


### PR DESCRIPTION
Since Ed25519 curve primitives are available since cryptography package
version 2.6 need to bump its version.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>