### PR TITLE
Allow imgtool to generated encrypted ed25519 keys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ matrix:
       language: go
       env: TEST=mynewt
       go:
-        - "1.11"
+        - "1.12"
 
 before_install:
   - |

--- a/docs/design.md
+++ b/docs/design.md
@@ -97,6 +97,7 @@ struct image_tlv {
 #define IMAGE_TLV_ECDSA224          0x21   /* ECDSA of hash output */
 #define IMAGE_TLV_ECDSA256          0x22   /* ECDSA of hash output */
 #define IMAGE_TLV_RSA3072_PSS       0x23   /* RSA3072 of hash output */
+#define IMAGE_TLV_ED25519           0x24   /* ED25519 of hash output */
 ```
 
 Optional type-length-value records (TLVs) containing image metadata are placed

--- a/scripts/imgtool/main.py
+++ b/scripts/imgtool/main.py
@@ -42,7 +42,7 @@ def gen_ecdsa_p224(keyfile, passwd):
 
 
 def gen_ed25519(keyfile, passwd):
-    keys.Ed25519.generate().export_private(path=keyfile)
+    keys.Ed25519.generate().export_private(path=keyfile, passwd=passwd)
 
 
 valid_langs = ['c', 'rust']


### PR DESCRIPTION
This just adds the extra parameter for the password which was missing in the ed25519 key generation. `cryptography` and `openssl` can already correctly handle the generation of ed25519 encrypted keys.