### PR TITLE
zephyr: fix include of system_timer.h

### DIFF
--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -19,7 +19,7 @@
 #include <gpio.h>
 #include <misc/__assert.h>
 #include <flash.h>
-#include <drivers/system_timer.h>
+#include <drivers/timer/system_timer.h>
 #include <usb/usb_device.h>
 #include <soc.h>
 


### PR DESCRIPTION
Above header was moved to another path.

Which align to zephyr running master after https://github.com/zephyrproject-rtos/zephyr/commit/68c389c1f82aa2c6fedb0d077de31d86cd36bce2

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>