### PR TITLE
Fix bug that prevents split images from working.

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -1849,7 +1849,7 @@ split_go(int loader_slot, int split_slot, void **entry)
 
     loader_flash_id = flash_area_id_from_image_slot(loader_slot);
     rc = flash_area_open(loader_flash_id,
-                         &BOOT_IMG_AREA(&boot_data, split_slot));
+                         &BOOT_IMG_AREA(&boot_data, loader_slot));
     assert(rc == 0);
     split_flash_id = flash_area_id_from_image_slot(split_slot);
     rc = flash_area_open(split_flash_id,


### PR DESCRIPTION
There is a bug in split_go that never opens the loader image flash
area, but opens the app/split image flash area twice. This prevents
split_image_check from passing and the app from ever loading.

This should take care of https://github.com/JuulLabs-OSS/mcuboot/issues/499