### PR TITLE
The default buffer size of 0 usually isn't enough

### DIFF
--- a/boot/zephyr/prj.conf
+++ b/boot/zephyr/prj.conf
@@ -47,3 +47,5 @@ CONFIG_LOG=y
 CONFIG_LOG_IMMEDIATE=y
 ### Ensure Zephyr logging changes don't use more resources
 CONFIG_LOG_DEFAULT_LEVEL=0
+### Prevent serial output from getting cut off on some setups.
+CONFIG_LOG_BUFFER_SIZE=128


### PR DESCRIPTION
At least not for my setup. Serial output gets cut off.