### PR TITLE
Use Ninja instead of Makefiles for Zephyr

### DIFF
--- a/samples/zephyr/Makefile
+++ b/samples/zephyr/Makefile
@@ -106,10 +106,10 @@ boot: check
 	(mkdir -p $(BUILD_DIR_BOOT) && \
 		cd $(BUILD_DIR_BOOT) && \
 		cmake -DOVERLAY_CONFIG=$(BOOTLOADER_OVERLAY_CONFIG) \
-			-G"Unix Makefiles" \
+			-G"Ninja" \
 			-DBOARD=$(BOARD) \
 			$(SOURCE_DIRECTORY)/../../boot/zephyr && \
-		make -j$(nproc))
+		ninja)
 	cp $(BUILD_DIR_BOOT)/zephyr/zephyr.bin mcuboot.bin
 
 clean_boot: check
@@ -120,10 +120,10 @@ hello1: check
 	(mkdir -p $(BUILD_DIR_HELLO1) && \
 		cd $(BUILD_DIR_HELLO1) && \
 		cmake -DFROM_WHO=hello1 \
-			-G"Unix Makefiles" \
+			-G"Ninja" \
 			-DBOARD=$(BOARD) \
 			$(SOURCE_DIRECTORY)/hello-world && \
-		make -j$(nproc))
+		ninja)
 	$(IMGTOOL) sign \
 		--key $(SIGNING_KEY) \
 		--header-size $(BOOT_HEADER_LEN) \
@@ -145,10 +145,10 @@ hello2: check
 	(mkdir -p $(BUILD_DIR_HELLO2) && \
 		cd $(BUILD_DIR_HELLO2) && \
 		cmake -DFROM_WHO=hello2 \
-			-G"Unix Makefiles" \
+			-G"Ninja" \
 			-DBOARD=$(BOARD) \
 			$(SOURCE_DIRECTORY)/hello-world && \
-		make -j$(nproc))
+		ninja)
 	$(IMGTOOL) sign \
 		--key $(SIGNING_KEY) \
 		--header-size $(BOOT_HEADER_LEN) \

--- a/samples/zephyr/README.md
+++ b/samples/zephyr/README.md
@@ -8,3 +8,17 @@ useful.
 
 Please see the comments in the Makefile in this directory for more
 details on how to build and test this application.
+
+Note that this sample uses the "ninja" build tool, which can be
+installed on most systems using the system package manager, e.g., for
+a Debian-based distro:
+
+```
+$ sudo apt-get install ninja
+```
+
+or in Fedora:
+
+```
+$ sudo dnf install ninja
+```


### PR DESCRIPTION
Zephyr builds use 'cmake' which can generate either makefiles, or use
the Ninja build tools.  There are several significant advantages to
using Ninja as the build tool:

  - It is significantly faster.  Ninja reads a directory and stats the
    files in it once.  Make often stats a given directory thousands of
    times, many for files that don't even exist.

  - It has better output.  Ninja collects commands together with their
    error output.  When doing multi-cpu builds, Ninja prints a status
    indicator, and only prints fully verbose commands when that command
    fails.  Instead of having to try an piece together a given command
    with its errors, they will always be together.

  - Make's support of multiple CPUs is a crude hack.  Make forks off
    multiple processes to use multiple CPUs.  These processes don't
    communicate with each other (very much), which causes make to often
    continue after enountering errors.  It is common for a multi-CPU
    make invocation to print hundreds or thousands of additional lines
    after an error message.

Nearly all distros have a version of Ninja available in their package
manager, making this change of low cost.

Signed-off-by: David Brown <david.brown@linaro.org>