### PR TITLE
image: use explitic padding on dependency version

### DIFF
--- a/boot/bootutil/include/bootutil/image.h
+++ b/boot/bootutil/include/bootutil/image.h
@@ -91,6 +91,8 @@ struct image_version {
 
 struct image_dependency {
     uint8_t image_id;                       /* Image index (from 0) */
+    uint8_t _pad1;
+    uint16_t _pad2;
     struct image_version image_min_version; /* Indicates at minimum which
                                              * version of firmware must be
                                              * available to satisfy compliance

--- a/scripts/imgtool/image.py
+++ b/scripts/imgtool/image.py
@@ -202,7 +202,7 @@ class Image():
             for i in range(dependencies_num):
                 e = STRUCT_ENDIAN_DICT[self.endian]
                 payload = struct.pack(
-                                e + 'I'+'BBHI',
+                                e + 'B3x'+'BBHI',
                                 int(dependencies[DEP_IMAGES_KEY][i]),
                                 dependencies[DEP_VERSIONS_KEY][i].major,
                                 dependencies[DEP_VERSIONS_KEY][i].minor,


### PR DESCRIPTION
This struct currently relies on padding being done by the C compiler.
Although this is generally done the same across targets, this isn't
required, and it is better to make any padding explicit.  This also
makes it clear that there is extra space in this structure that can be
used for another purpose.

The python imgtool is also fixed to match.  It was using a 32-bit int,
which only worked in the little endian case.

Signed-off-by: David Brown <david.brown@linaro.org>