### PR TITLE
Sim tests for dependencies

### DIFF
--- a/sim/Cargo.lock
+++ b/sim/Cargo.lock
@@ -17,7 +17,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "block-cipher-trait 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "opaque-debug 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -81,7 +81,7 @@ name = "base64"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -104,6 +104,7 @@ version = "0.1.0"
 dependencies = [
  "aes-ctr 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -120,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "byteorder"
-version = "1.2.7"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -562,7 +563,7 @@ dependencies = [
 "checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum block-cipher-trait 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1c924d49bd09e7c06003acda26cd9742e796e34282ec6c1189404dee0c1f4774"
-"checksum byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "94f88df23a25417badc922ab0f5716cc1330e87f71ddd9203b3a3ccd9cedf75d"
+"checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 "checksum cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4a8b715cb4597106ea87c7c84b2f1d452c7492033765df7f32651e66fcf749"
 "checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
 "checksum ctr 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "28912c12ae9ba20d6971168379d1482a4ce17f4855f23218ffb53ddc91fbe69b"

--- a/sim/Cargo.toml
+++ b/sim/Cargo.toml
@@ -19,6 +19,7 @@ bootstrap = ["mcuboot-sys/bootstrap"]
 multiimage = ["mcuboot-sys/multiimage"]
 
 [dependencies]
+byteorder = "1.3"
 libc = "0.2.0"
 rand = "0.4.0"
 docopt = "0.8"

--- a/sim/src/depends.rs
+++ b/sim/src/depends.rs
@@ -1,0 +1,133 @@
+//! Support and tests related to the dependency management for multi-image
+//! support.
+
+use crate::image::ImageVersion;
+
+pub trait Depender {
+    /// Generate a version for this particular image.  The slot indicates
+    /// which slot this is being put in.
+    fn my_version(&self, offset: usize, slot: usize) -> ImageVersion;
+
+    /// Return dependencies for this image/slot combination.
+    fn my_deps(&self, offset: usize, slot: usize) -> Vec<ImageVersion>;
+
+    /// Return the image ID of the other version.
+    fn other_id(&self) -> u8;
+}
+
+/// A boring image is used when we aren't testing dependencies.  There will
+/// be meaningful version numbers.  The size field is the image number we
+/// are.
+pub struct BoringDep(pub usize);
+
+impl Depender for BoringDep {
+    fn my_version(&self, _offset: usize, slot: usize) -> ImageVersion {
+        ImageVersion::new_synthetic(self.0 as u8, slot as u8, 0)
+    }
+
+    fn my_deps(&self, _offset: usize, _slot: usize) -> Vec<ImageVersion> {
+        vec![]
+    }
+
+    fn other_id(&self) -> u8 {
+        0
+    }
+}
+
+/// An individual test of the dependency mechanism describes one of the
+/// possibilities for the dependency information for each image, and what
+/// the expected outcome is.
+#[derive(Clone, Debug)]
+pub struct DepTest {
+    /// What kinds of dependency should be installed in the image.
+    pub depends: [DepType; 2],
+
+    /// What is the expected outcome of the upgrade.
+    pub upgrades: [UpgradeInfo; 2],
+}
+
+/// Describes the various types of dependency information that can be
+/// provided.
+#[derive(Clone, Debug)]
+pub enum DepType {
+    /// Do not include dependency information
+    Nothing,
+    /// Provide dependency information that matches the other image.
+    Correct,
+    /// Provide dependency information describing something newer than the
+    /// other image.
+    Newer,
+}
+
+/// Describes what our expectation is for an upgrade.
+#[derive(Clone, Debug)]
+pub enum UpgradeInfo {
+    /// The current version should be held.
+    Held,
+    /// The image should be upgraded
+    Upgraded,
+}
+
+/// A "test" that gives no dependency information.
+pub static NO_DEPS: DepTest = DepTest {
+    depends: [DepType::Nothing, DepType::Nothing],
+    upgrades: [UpgradeInfo::Upgraded, UpgradeInfo::Upgraded],
+};
+
+/// A PairDep describes the dependencies between two pairs.
+pub struct PairDep {
+    /// The image number of this image.
+    number: usize,
+
+    test: DepTest,
+}
+
+impl PairDep {
+    pub fn new(total_image: usize, my_image: usize, deps: &DepTest) -> PairDep {
+        if total_image != 2 {
+            panic!("PairDep only works when there are two images");
+        }
+
+        PairDep {
+            number: my_image,
+            test: deps.clone(),
+        }
+    }
+}
+
+impl Depender for PairDep {
+    fn my_version(&self, _offset: usize, slot: usize) -> ImageVersion {
+        ImageVersion::new_synthetic(self.number as u8, slot as u8, 0)
+    }
+
+    fn my_deps(&self, _offset: usize, slot: usize) -> Vec<ImageVersion> {
+        match self.test.depends[slot] {
+            DepType::Nothing => vec![],
+            DepType::Correct => vec![
+                ImageVersion::new_synthetic(self.other_id(), slot as u8, 0)
+            ],
+            DepType::Newer => vec![
+                ImageVersion::new_synthetic(self.other_id(), slot as u8, 1)
+            ],
+        }
+    }
+
+    fn other_id(&self) -> u8 {
+        (1 - self.number) as u8
+    }
+}
+
+impl ImageVersion {
+    /// Generate an image version based on some key information.  The image
+    /// number influences the major version number (by an arbitrary factor),
+    /// and the slot affects the major number on the build_number.  The minor
+    /// number can also be given to force numbers to be different.
+    fn new_synthetic(image_id: u8, slot: u8, minor: u8) -> ImageVersion {
+        ImageVersion {
+            major: image_id * 20 + slot,
+            minor: minor,
+            revision: 1,
+            build_num: slot as u32,
+        }
+    }
+}

--- a/sim/src/image.rs
+++ b/sim/src/image.rs
@@ -1032,7 +1032,7 @@ fn install_image(flash: &mut SimMultiFlash, slot: &SlotInfo, len: usize,
         magic: tlv.get_magic(),
         load_addr: 0,
         hdr_size: HDR_SIZE as u16,
-        _pad1: 0,
+        protect_tlv_size: tlv.protect_size(),
         img_size: len as u32,
         flags: tlv.get_flags(),
         ver: ImageVersion {
@@ -1299,7 +1299,7 @@ pub struct ImageHeader {
     magic: u32,
     load_addr: u32,
     hdr_size: u16,
-    _pad1: u16,
+    protect_tlv_size: u16,
     img_size: u32,
     flags: u32,
     ver: ImageVersion,
@@ -1309,11 +1309,12 @@ pub struct ImageHeader {
 impl AsRaw for ImageHeader {}
 
 #[repr(C)]
+#[derive(Clone)]
 pub struct ImageVersion {
-    major: u8,
-    minor: u8,
-    revision: u16,
-    build_num: u32,
+    pub major: u8,
+    pub minor: u8,
+    pub revision: u16,
+    pub build_num: u32,
 }
 
 #[derive(Clone)]

--- a/sim/src/lib.rs
+++ b/sim/src/lib.rs
@@ -7,13 +7,21 @@ use std::{
 use serde_derive::Deserialize;
 
 mod caps;
+mod depends;
 mod image;
 mod tlv;
 pub mod testlog;
 
-pub use crate::image::{
-    ImagesBuilder,
-    show_sizes,
+pub use crate::{
+    depends::{
+        DepTest,
+        DepType,
+        UpgradeInfo,
+        NO_DEPS,},
+    image::{
+        ImagesBuilder,
+        show_sizes,
+    },
 };
 
 const USAGE: &'static str = "
@@ -179,10 +187,10 @@ impl RunStatus {
 
         failed |= bad_secondary_slot_image.run_signfail_upgrade();
 
-        let images = run.clone().make_no_upgrade_image();
+        let images = run.clone().make_no_upgrade_image(&NO_DEPS);
         failed |= images.run_norevert_newimage();
 
-        let images = run.make_image(true);
+        let images = run.make_image(&NO_DEPS, true);
 
         failed |= images.run_basic_revert();
         failed |= images.run_revert_with_fails();

--- a/sim/src/tlv.rs
+++ b/sim/src/tlv.rs
@@ -8,6 +8,9 @@
 //! Because of this header, we have to make two passes.  The first pass will compute the size of
 //! the TLV, and the second pass will build the data for the TLV.
 
+use byteorder::{
+    LittleEndian, WriteBytesExt,
+};
 use pem;
 use base64;
 use ring::{digest, rand};
@@ -200,8 +203,7 @@ impl ManifestGen for TlvGen {
         let size = self.get_size();
         result.push(0x07);
         result.push(0x69);
-        result.push((size & 0xFF) as u8);
-        result.push(((size >> 8) & 0xFF) as u8);
+        result.write_u16::<LittleEndian>(size).unwrap();
 
         if self.kinds.contains(&TlvKinds::SHA256) {
             let hash = digest::digest(&digest::SHA256, &self.payload);
@@ -259,8 +261,7 @@ impl ManifestGen for TlvGen {
                 result.push(TlvKinds::RSA3072 as u8);
             }
             result.push(0);
-            result.push((signature.len() & 0xFF) as u8);
-            result.push(((signature.len() >> 8) & 0xFF) as u8);
+            result.write_u16::<LittleEndian>(signature.len() as u16).unwrap();
             result.extend_from_slice(&signature);
         }
 
@@ -295,8 +296,7 @@ impl ManifestGen for TlvGen {
                 signature[1] += 1;
             }
 
-            result.push((signature.len() & 0xFF) as u8);
-            result.push(((signature.len() >> 8) & 0xFF) as u8);
+            result.write_u16::<LittleEndian>(signature.len() as u16).unwrap();
             result.extend_from_slice(signature.as_ref());
         }
 
@@ -327,8 +327,7 @@ impl ManifestGen for TlvGen {
             result.push(0);
 
             let signature = signature.as_ref().to_vec();
-            result.push((signature.len() & 0xFF) as u8);
-            result.push(((signature.len() >> 8) & 0xFF) as u8);
+            result.write_u16::<LittleEndian>(signature.len() as u16).unwrap();
             result.extend_from_slice(signature.as_ref());
         }
 

--- a/sim/src/tlv.rs
+++ b/sim/src/tlv.rs
@@ -26,7 +26,7 @@ use untrusted;
 use mcuboot_sys::c;
 
 #[repr(u8)]
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[allow(dead_code)] // TODO: For now
 pub enum TlvKinds {
     KEYHASH = 0x01,
@@ -74,6 +74,7 @@ pub trait ManifestGen {
     fn make_tlv(self: Box<Self>) -> Vec<u8>;
 }
 
+#[derive(Debug)]
 pub struct TlvGen {
     flags: u32,
     kinds: Vec<TlvKinds>,
@@ -85,6 +86,7 @@ pub struct TlvGen {
     dependencies: Vec<Dependency>,
 }
 
+#[derive(Debug)]
 struct Dependency {
     id: u8,
     version: ImageVersion,

--- a/sim/tests/core.rs
+++ b/sim/tests/core.rs
@@ -2,28 +2,75 @@
 //!
 //! Run the existing testsuite as a Rust unit test.
 
-use bootsim::{ImagesBuilder, testlog};
+use bootsim::{
+    DepTest, DepType, UpgradeInfo,
+    ImagesBuilder,
+    NO_DEPS,
+    testlog,
+};
 
-macro_rules! sim_test {
-    ($name:ident, $maker:ident($($margs:expr),*), $test:ident($($targs:expr),*)) => {
+/// A single test, after setting up logging and such.  Within the $body,
+/// $arg will be bound to each device.
+macro_rules! test_shell {
+    ($name:ident, $arg: ident, $body:expr) => {
         #[test]
         fn $name() {
             testlog::setup();
-
-            ImagesBuilder::each_device(|r| {
-                let image = r.$maker($($margs),*);
-                assert!(!image.$test($($targs),*));
+            ImagesBuilder::each_device(|$arg| {
+                $body;
             });
         }
+    }
+}
+
+/// A typical test calls a particular constructor, and runs a given test on
+/// that constructor.
+macro_rules! sim_test {
+    ($name:ident, $maker:ident($($margs:expr),*), $test:ident($($targs:expr),*)) => {
+        test_shell!($name, r, {
+            let image = r.$maker($($margs),*);
+            assert!(!image.$test($($targs),*));
+        });
     };
 }
 
 sim_test!(bad_secondary_slot, make_bad_secondary_slot_image(), run_signfail_upgrade());
-sim_test!(norevert_newimage, make_no_upgrade_image(), run_norevert_newimage());
-sim_test!(basic_revert, make_image(true), run_basic_revert());
-sim_test!(revert_with_fails, make_image(false), run_revert_with_fails());
-sim_test!(perm_with_fails, make_image(true), run_perm_with_fails());
-sim_test!(perm_with_random_fails, make_image(true), run_perm_with_random_fails(5));
-sim_test!(norevert, make_image(true), run_norevert());
-sim_test!(status_write_fails_complete, make_image(true), run_with_status_fails_complete());
-sim_test!(status_write_fails_with_reset, make_image(true), run_with_status_fails_with_reset());
+sim_test!(norevert_newimage, make_no_upgrade_image(&NO_DEPS), run_norevert_newimage());
+sim_test!(basic_revert, make_image(&NO_DEPS, true), run_basic_revert());
+sim_test!(revert_with_fails, make_image(&NO_DEPS, false), run_revert_with_fails());
+sim_test!(perm_with_fails, make_image(&NO_DEPS, true), run_perm_with_fails());
+sim_test!(perm_with_random_fails, make_image(&NO_DEPS, true), run_perm_with_random_fails(5));
+sim_test!(norevert, make_image(&NO_DEPS, true), run_norevert());
+sim_test!(status_write_fails_complete, make_image(&NO_DEPS, true), run_with_status_fails_complete());
+sim_test!(status_write_fails_with_reset, make_image(&NO_DEPS, true), run_with_status_fails_with_reset());
+
+// Test various combinations of incorrect dependencies.
+test_shell!(dependency_combos, r, {
+    // Only test setups with two images.
+    if r.num_images() != 2 {
+        return;
+    }
+
+    for dep in TEST_DEPS {
+        let image = r.clone().make_image(&dep, true);
+        assert!(!image.run_check_deps(&dep));
+    }
+});
+
+/// These are the variants of dependencies we will test.
+pub static TEST_DEPS: &[DepTest] = &[
+    // First is a sanity test, no dependencies should upgrade.
+    DepTest {
+        depends: [DepType::Nothing, DepType::Nothing],
+        upgrades: [UpgradeInfo::Upgraded, UpgradeInfo::Upgraded],
+    },
+
+    // If all of the dependencies are unmet, there should be no upgrades.
+    // TODO: Disabled because it fails.
+    /*
+    DepTest {
+        depends: [DepType::Newer, DepType::Newer],
+        upgrades: [UpgradeInfo::Held, UpgradeInfo::Held],
+    },
+    */
+];


### PR DESCRIPTION
This adds some changes that support testing dependencies within the simulator. Currently, there is a simple test case for incorrect dependencies, but it is disabled because the mcuboot code hangs in this configuration.