### PR TITLE
Add Mynewt option to enable the watchdog

### DIFF
--- a/boot/mynewt/mcuboot_config/include/mcuboot_config/mcuboot_config.h
+++ b/boot/mynewt/mcuboot_config/include/mcuboot_config/mcuboot_config.h
@@ -73,7 +73,7 @@
 
 #define MCUBOOT_MAX_IMG_SECTORS       MYNEWT_VAL(BOOTUTIL_MAX_IMG_SECTORS)
 
-#if MYNEWT_VAL(WATCHDOG_INTERVAL)
+#if MYNEWT_VAL(BOOTUTIL_FEED_WATCHDOG) && MYNEWT_VAL(WATCHDOG_INTERVAL)
 #include <hal/hal_watchdog.h>
 #define MCUBOOT_WATCHDOG_FEED()    \
     do {                           \

--- a/boot/mynewt/mcuboot_config/syscfg.yml
+++ b/boot/mynewt/mcuboot_config/syscfg.yml
@@ -83,3 +83,6 @@ syscfg.defs:
     BOOTUTIL_BOOTSTRAP:
         description: 'Support bootstrapping slot0 from slot1, if slot0 is empty'
         value: 0
+    BOOTUTIL_FEED_WATCHDOG:
+        description: 'Enable watchdog feeding while performing a swap upgrade'
+        value: 0


### PR DESCRIPTION
For Mynewt, if a watchdog driver is available, it is always used and feed during a swap operation. Since the swap operation is able to resist resets, the watchdog can stay disabled to preserve some flash space (watchdog driver), with the side-effect that a swap might take longer because of having to resume interrupted operations.