### PR TITLE
scripts: allow user to set load_addr

### DIFF
--- a/scripts/imgtool/image.py
+++ b/scripts/imgtool/image.py
@@ -103,7 +103,7 @@ class Image():
     def __init__(self, version=None, header_size=IMAGE_HEADER_SIZE,
                  pad_header=False, pad=False, align=1, slot_size=0,
                  max_sectors=DEFAULT_MAX_SECTORS, overwrite_only=False,
-                 endian="little"):
+                 endian="little", load_addr=0):
         self.version = version or versmod.decode_version("0")
         self.header_size = header_size
         self.pad_header = pad_header
@@ -114,15 +114,17 @@ class Image():
         self.overwrite_only = overwrite_only
         self.endian = endian
         self.base_addr = None
+        self.load_addr = 0 if load_addr is None else load_addr
         self.payload = []
 
     def __repr__(self):
-        return "<Image version={}, header_size={}, base_addr={}, \
+        return "<Image version={}, header_size={}, base_addr={}, load_addr={}, \
                 align={}, slot_size={}, max_sectors={}, overwrite_only={}, \
                 endian={} format={}, payloadlen=0x{:x}>".format(
                     self.version,
                     self.header_size,
                     self.base_addr if self.base_addr is not None else "N/A",
+                    self.load_addr,
                     self.align,
                     self.slot_size,
                     self.max_sectors,
@@ -292,7 +294,7 @@ class Image():
         assert struct.calcsize(fmt) == IMAGE_HEADER_SIZE
         header = struct.pack(fmt,
                 IMAGE_MAGIC,
-                0, # LoadAddr
+                self.load_addr,
                 self.header_size,
                 protected_tlv_size,  # TLV Info header + Dependency TLVs
                 len(self.payload) - self.header_size, # ImageSz

--- a/scripts/imgtool/main.py
+++ b/scripts/imgtool/main.py
@@ -182,6 +182,8 @@ class BasedIntParamType(click.ParamType):
 
 @click.argument('outfile')
 @click.argument('infile')
+@click.option('-L', '--load-addr', type=BasedIntParamType(), required=False,
+              help='Load address for image when it is in its primary slot.')
 @click.option('-E', '--encrypt', metavar='filename',
               help='Encrypt image using the provided public key')
 @click.option('-e', '--endian', type=click.Choice(['little', 'big']),
@@ -207,14 +209,14 @@ class BasedIntParamType(click.ParamType):
 @click.option('-k', '--key', metavar='filename')
 @click.command(help='''Create a signed or unsigned image\n
                INFILE and OUTFILE are parsed as Intel HEX if the params have
-               .hex extension, othewise binary format is used''')
+               .hex extension, otherwise binary format is used''')
 def sign(key, align, version, header_size, pad_header, slot_size, pad,
          max_sectors, overwrite_only, endian, encrypt, infile, outfile,
-         dependencies):
+         dependencies, load_addr):
     img = image.Image(version=decode_version(version), header_size=header_size,
                       pad_header=pad_header, pad=pad, align=int(align),
                       slot_size=slot_size, max_sectors=max_sectors,
-                      overwrite_only=overwrite_only, endian=endian)
+                      overwrite_only=overwrite_only, endian=endian, load_addr=load_addr)
     img.load(infile)
     key = load_key(key) if key else None
     enckey = load_key(encrypt) if encrypt else None


### PR DESCRIPTION
Allow the user to set the load_addr field of the header.
This could be useful in multi image situations to help
deduce the image number of an update without having to
look at the swap info.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>