### PR TITLE
Use better naming for swap copy/erase functions

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -2262,18 +2262,17 @@ boot_prepare_image_for_update(struct boot_loader_state *state,
                  * magic, so also run validation on the primary slot to be
                  * sure it's not OK.
                  */
-                 if (boot_check_header_erased(state, BOOT_PRIMARY_SLOT) == 0 ||
-                     boot_validate_slot(state, BOOT_PRIMARY_SLOT, bs) != 0) {
-                     if (boot_img_hdr(state,
-                          BOOT_SECONDARY_SLOT)->ih_magic == IMAGE_MAGIC &&
-                         boot_validate_slot(state, BOOT_SECONDARY_SLOT, bs) == 0)
-                     {
+                if (boot_check_header_erased(state, BOOT_PRIMARY_SLOT) == 0 ||
+                        boot_validate_slot(state, BOOT_PRIMARY_SLOT, bs) != 0) {
+                    if (boot_img_hdr(state,
+                            BOOT_SECONDARY_SLOT)->ih_magic == IMAGE_MAGIC &&
+                            boot_validate_slot(state, BOOT_SECONDARY_SLOT, bs) == 0) {
                         /* Set swap type to REVERT to overwrite the primary
                          * slot with the image contained in secondary slot
                          * and to trigger the explicit setting of the
                          * image_ok flag.
                          */
-                         BOOT_SWAP_TYPE(state) = BOOT_SWAP_TYPE_REVERT;
+                        BOOT_SWAP_TYPE(state) = BOOT_SWAP_TYPE_REVERT;
                     }
                 }
             }

--- a/docs/design.md
+++ b/docs/design.md
@@ -616,30 +616,33 @@ according to the following procedure:
    To be compatible, both have to have only sectors that can fit into the
    scratch area and if one of them has larger sectors than the other, it must
    be able to entirely fit some rounded number of sectors from the other slot.
-2. Iterate the list of sector indices in descending order (i.e., starting
-   with the greatest index); only sectors that are predetermined to be part of
+   In the next steps we'll use the terminology "region" for the total amount of
+   data copied/erased because this can be any amount of sectors depending on
+   how many the scratch is able to fit for some swap operation.
+2. Iterate the list of region indices in descending order (i.e., starting
+   with the greatest index); only regions that are predetermined to be part of
    the image are copied; current element = "index".
     + a. Erase scratch area.
     + b. Copy secondary_slot[index] to scratch area.
-        - If this is the last sector in the slot, scratch area has a temporary
+        - If this is the last region in the slot, scratch area has a temporary
           status area initialized to store the initial state, because the
-          primary slot's last sector will have to be erased. In this case,
+          primary slot's last region will have to be erased. In this case,
           only the data that was calculated to amount to the image is copied.
-        - Else if this is the first swapped sector but not the last sector in
+        - Else if this is the first swapped region but not the last region in
           the slot, initialize the status area in primary slot and copy the
-          full sector contents.
-        - Else, copy entire sector contents.
+          full region contents.
+        - Else, copy entire region contents.
     + c. Write updated swap status (i).
     + d. Erase secondary_slot[index]
     + e. Copy primary_slot[index] to secondary_slot[index] according to amount
          previosly copied at step b.
-        - If this is not the last sector in the slot, erase the trailer in the
+        - If this is not the last region in the slot, erase the trailer in the
           secondary slot, to always use the one in the primary slot.
     + f. Write updated swap status (ii).
     + g. Erase primary_slot[index].
     + h. Copy scratch area to primary_slot[index] according to amount
          previously copied at step b.
-        - If this is the last sector in the slot, the status is read from
+        - If this is the last region in the slot, the status is read from
           scratch (where it was stored temporarily) and written anew in the
           primary slot.
     + i. Write updated swap status (iii).
@@ -650,7 +653,7 @@ trailer can be written by the user at a later time.  With the image trailer
 unwritten, the user can test the image in the secondary slot
 (i.e., transition to state II).
 
-Note1: If the sector being copied is the last sector, then swap status is
+Note1: If the region being copied contains the last sector, then swap status is
 temporarily maintained on scratch for the duration of this operation, always
 using the primary slot's area otherwise.
 


### PR DESCRIPTION
Since a copy/erase during a swap can result in some number of sectors erased and copied, which is not necessarily equal to 1, update design document and bootloader function naming to reflect this fact, by using the postfix "_region" instead of "_sector" in those cases.

This fixes #541