### PR TITLE
Imgtool versioning

### DIFF
--- a/scripts/imgtool/__init__.py
+++ b/scripts/imgtool/__init__.py
@@ -11,3 +11,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+imgtool_version = "1.4.0a3"

--- a/scripts/imgtool/main.py
+++ b/scripts/imgtool/main.py
@@ -20,7 +20,7 @@ import click
 import getpass
 import imgtool.keys as keys
 import sys
-from imgtool import image
+from imgtool import image, imgtool_version
 from imgtool.version import decode_version
 
 
@@ -249,6 +249,11 @@ class AliasesGroup(click.Group):
         return None
 
 
+@click.command(help='Print imgtool version information')
+def version():
+    print(imgtool_version)
+
+
 @click.command(cls=AliasesGroup,
                context_settings=dict(help_option_names=['-h', '--help']))
 def imgtool():
@@ -259,6 +264,7 @@ imgtool.add_command(keygen)
 imgtool.add_command(getpub)
 imgtool.add_command(verify)
 imgtool.add_command(sign)
+imgtool.add_command(version)
 
 
 if __name__ == '__main__':

--- a/scripts/imgtool/main.py
+++ b/scripts/imgtool/main.py
@@ -216,7 +216,8 @@ def sign(key, align, version, header_size, pad_header, slot_size, pad,
     img = image.Image(version=decode_version(version), header_size=header_size,
                       pad_header=pad_header, pad=pad, align=int(align),
                       slot_size=slot_size, max_sectors=max_sectors,
-                      overwrite_only=overwrite_only, endian=endian, load_addr=load_addr)
+                      overwrite_only=overwrite_only, endian=endian,
+                      load_addr=load_addr)
     img.load(infile)
     key = load_key(key) if key else None
     enckey = load_key(encrypt) if encrypt else None

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -5,6 +5,7 @@ setuptools.setup(
     name="imgtool",
     version=imgtool_version,
     author="The MCUboot commiters",
+    author_email="None",
     description=("MCUboot's image signing and key management"),
     license="Apache Software License",
     url="http://github.com/JuulLabs-OSS/mcuboot",

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -1,8 +1,9 @@
 import setuptools
+from imgtool import imgtool_version
 
 setuptools.setup(
     name="imgtool",
-    version="1.3.1",
+    version=imgtool_version,
     author="The MCUboot commiters",
     description=("MCUboot's image signing and key management"),
     license="Apache Software License",


### PR DESCRIPTION
This adds the simplest possible image versioning support to imgtool, supporting the command `imgtool version` and `pip show imgtool`. Also promotes the current version to `1.4.0a3`. No Travis-CI wheel building support added yet.