### PR TITLE
New protected TLV format

### DIFF
--- a/boot/bootutil/include/bootutil/image.h
+++ b/boot/bootutil/include/bootutil/image.h
@@ -41,6 +41,7 @@ struct flash_area;
 #define IMAGE_MAGIC_V1              0x96f3b83c
 #define IMAGE_MAGIC_NONE            0xffffffff
 #define IMAGE_TLV_INFO_MAGIC        0x6907
+#define IMAGE_TLV_PROT_INFO_MAGIC   0x6908
 
 #define IMAGE_HEADER_SIZE           32
 
@@ -150,7 +151,7 @@ struct image_tlv_iter {
     const struct flash_area *fap;
     uint8_t type;
     bool prot;
-    uint16_t prot_len;
+    uint16_t prot_end;
     uint32_t tlv_off;
     uint32_t tlv_end;
 };

--- a/boot/bootutil/src/image_validate.c
+++ b/boot/bootutil/src/image_validate.c
@@ -61,15 +61,15 @@ bootutil_img_hash(struct enc_key_data *enc_state, int image_index,
     uint16_t hdr_size;
     uint32_t off;
     int rc;
-#ifdef MCUBOOT_ENC_IMAGES
-    uint32_t protected_off;
     uint32_t blk_off;
-#endif
+    uint32_t tlv_off;
 
 #if (BOOT_IMAGE_NUMBER == 1) || !defined(MCUBOOT_ENC_IMAGES)
     (void)enc_state;
     (void)image_index;
     (void)hdr_size;
+    (void)blk_off;
+    (void)tlv_off;
 #endif
 
 #ifdef MCUBOOT_ENC_IMAGES
@@ -89,25 +89,18 @@ bootutil_img_hash(struct enc_key_data *enc_state, int image_index,
     }
 
     /* Hash is computed over image header and image itself. */
-    hdr_size = hdr->ih_hdr_size;
-    size = BOOT_TLV_OFF(hdr);
+    size = hdr_size = hdr->ih_hdr_size;
+    size += hdr->ih_img_size;
+    tlv_off = size;
 
-#ifdef MCUBOOT_ENC_IMAGES
-    protected_off = size;
-#endif
-
-#if (MCUBOOT_IMAGE_NUMBER > 1)
-    /* If dependency TLVs are present then the TLV info header and the
-     * dependency TLVs are also protected and have to be included in the hash
-     * calculation.
-     */
-    if (hdr->ih_protect_tlv_size != 0) {
-        size += hdr->ih_protect_tlv_size;
-    }
-#endif
+    /* If protected TLVs are present they are also hashed. */
+    size += hdr->ih_protect_tlv_size;
 
     for (off = 0; off < size; off += blk_sz) {
         blk_sz = size - off;
+        if (blk_sz > tmp_buf_sz) {
+            blk_sz = tmp_buf_sz;
+        }
 #ifdef MCUBOOT_ENC_IMAGES
         /* The only data that is encrypted in an image is the payload;
          * both header and TLVs (when protected) are not.
@@ -115,24 +108,20 @@ bootutil_img_hash(struct enc_key_data *enc_state, int image_index,
         if ((off < hdr_size) && ((off + blk_sz) > hdr_size)) {
             /* read only the header */
             blk_sz = hdr_size - off;
-        } else if (off >= protected_off) {
-            /* read protected TLVs */
-            blk_sz = size - off;
-        } else if ((off + blk_sz) > protected_off) {
-            /* do not copy beyond image payload */
-            blk_sz = protected_off - off;
+        }
+        if ((off < tlv_off) && ((off + blk_sz) > tlv_off)) {
+            /* read only up to the end of the image payload */
+            blk_sz = tlv_off - off;
         }
 #endif
-        if (blk_sz > tmp_buf_sz) {
-            blk_sz = tmp_buf_sz;
-        }
         rc = flash_area_read(fap, off, tmp_buf, blk_sz);
         if (rc) {
             return rc;
         }
 #ifdef MCUBOOT_ENC_IMAGES
         if (MUST_DECRYPT(fap, image_index, hdr)) {
-            if (off >= hdr_size && off < protected_off) {
+            /* Only payload is encrypted (area between header and TLVs) */
+            if (off >= hdr_size && off < tlv_off) {
                 blk_off = (off - hdr_size) & 0xf;
                 boot_encrypt(enc_state, image_index, fap, off - hdr_size,
                         blk_sz, blk_off, tmp_buf);

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -253,6 +253,7 @@ boot_read_image_size(struct boot_loader_state *state, int slot, uint32_t *size)
     const struct flash_area *fap;
     struct image_tlv_info info;
     uint32_t off;
+    uint32_t protect_tlv_size;
     int area_id;
     int rc;
 
@@ -274,12 +275,28 @@ boot_read_image_size(struct boot_loader_state *state, int slot, uint32_t *size)
         goto done;
     }
 
+    protect_tlv_size = boot_img_hdr(state, slot)->ih_protect_tlv_size;
+    if (info.it_magic == IMAGE_TLV_PROT_INFO_MAGIC) {
+        if (protect_tlv_size != info.it_tlv_tot) {
+            rc = BOOT_EBADIMAGE;
+            goto done;
+        }
+
+        if (flash_area_read(fap, off + info.it_tlv_tot, &info, sizeof(info))) {
+            rc = BOOT_EFLASH;
+            goto done;
+        }
+    } else if (protect_tlv_size != 0) {
+        rc = BOOT_EBADIMAGE;
+        goto done;
+    }
+
     if (info.it_magic != IMAGE_TLV_INFO_MAGIC) {
         rc = BOOT_EBADIMAGE;
         goto done;
     }
 
-    *size = off + info.it_tlv_tot;
+    *size = off + protect_tlv_size + info.it_tlv_tot;
     rc = 0;
 
 done:

--- a/sim/src/image.rs
+++ b/sim/src/image.rs
@@ -1153,10 +1153,11 @@ fn install_image(flash: &mut SimMultiFlash, slot: &SlotInfo, len: usize,
         tlv.make_tlv()
     };
 
+    let dev = flash.get_mut(&dev_id).unwrap();
+
     // Pad the block to a flash alignment (8 bytes).
     while b_tlv.len() % 8 != 0 {
-        //FIXME: should be erase_val?
-        b_tlv.push(0xFF);
+        b_tlv.push(dev.erased_val());
     }
 
     let mut buf = vec![];
@@ -1175,8 +1176,6 @@ fn install_image(flash: &mut SimMultiFlash, slot: &SlotInfo, len: usize,
     // an encrypted image, re-read to use for verification, erase + flash
     // un-encrypted. In the secondary slot the image is written un-encrypted,
     // and if encryption is requested, it follows an erase + flash encrypted.
-
-    let dev = flash.get_mut(&dev_id).unwrap();
 
     if slot.index == 0 {
         let enc_copy: Option<Vec<u8>>;


### PR DESCRIPTION
When using protected TLVs (for dependencies) the image validation was run over header + payload + tlv_info + protected TLVs. As a side-effect it was impossible to update the TLVs without rehashing (+ resigning) an image. This updates the validation routine to skip the tlv_info, so that hashing is run over header + payload + protected TLVs.

Fixes #539.

This is WIP, needs rebase after #549 is merged; `imgtool` and documentation changes in progress.