### PR TITLE
kconfig: add option for multi image

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -282,4 +282,10 @@ config MULTITHREADING
 	default n if SOC_FAMILY_NRF
 	default y
 
+config UPDATEABLE_IMAGE_NUMBER
+	int "Number of updateable images"
+	default 1
+	help
+	  Enables support of multi image update.
+
 source "$ZEPHYR_BASE/Kconfig.zephyr"


### PR DESCRIPTION
To enable multi image support in mcuboot one needs
to set the 'UPDATEABLE_IMAGE_NUMBER' config.
Add this to zephyrs MCUBoot kconfig to allow this.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>