### PR TITLE
zephyr/serial_recovery: fix serial device binding

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -248,6 +248,18 @@ config BOOT_SERIAL_DETECT_PIN_VAL
 	  Logic value of the detect pin which triggers serial recovery
 	  mode.
 
+# Workaround for not being able to have commas in macro arguments
+DT_CHOSEN_Z_CONSOLE := zephyr,console
+
+config RECOVERY_UART_DEV_NAME
+	string "UART Device Name for Recovery UART"
+	default "$(dt_chosen_label,$(DT_CHOSEN_Z_CONSOLE))" if HAS_DTS
+	default "UART_0"
+	depends on BOOT_SERIAL_UART
+	help
+	  This option specifies the name of UART device to be used for
+	  serial recovery.
+
 endif # MCUBOOT_SERIAL
 
 endmenu

--- a/boot/zephyr/serial_adapter.c
+++ b/boot/zephyr/serial_adapter.c
@@ -191,7 +191,7 @@ static int
 boot_uart_fifo_init(void)
 {
 #ifdef CONFIG_BOOT_SERIAL_UART
-	uart_dev = device_get_binding(DT_UART_CONSOLE_ON_DEV_NAME);
+	uart_dev = device_get_binding(CONFIG_RECOVERY_UART_DEV_NAME);
 #elif CONFIG_BOOT_SERIAL_CDC_ACM
 	uart_dev = device_get_binding(CONFIG_USB_CDC_ACM_DEVICE_NAME "_0");
 #endif


### PR DESCRIPTION
zephyr changes the way in which it provide name of
serial device used by serial recover.
see: https://github.com/zephyrproject-rtos/zephyr/pull/18752

This path introduce build time configuration of device name
which is set to exact the same device which was set before.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>