### PR TITLE
Fix Mynewt boot_serial unittest

### DIFF
--- a/boot/boot_serial/test/src/testcases/boot_serial_upload_bigger_image.c
+++ b/boot/boot_serial/test/src/testcases/boot_serial_upload_bigger_image.c
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+#include <flash_map_backend/flash_map_backend.h>
 #include <tinycbor/cborconstants_p.h>
 
 #include "boot_test.h"
@@ -105,7 +106,7 @@ TEST_CASE(boot_serial_upload_bigger_image)
     /*
      * Validate contents inside the primary slot
      */
-    rc = flash_area_open(FLASH_AREA_IMAGE_PRIMARY, &fap);
+    rc = flash_area_open(FLASH_AREA_IMAGE_PRIMARY(0), &fap);
     assert(rc == 0);
 
     for (off = 0; off < sizeof(img); off += sizeof(enc_img)) {

--- a/boot/mynewt/flash_map_backend/pkg.yml
+++ b/boot/mynewt/flash_map_backend/pkg.yml
@@ -11,3 +11,4 @@ pkg.homepage: "http://mcuboot.com"
 
 pkg.deps:
     - "@apache-mynewt-core/sys/flash_map"
+    - "@mcuboot/boot/mynewt/mcuboot_config"


### PR DESCRIPTION
The boot_serial test was failing build because it hadn't been updated to use new multi-image flash area nomenclature. This fixes the build.