### PR TITLE
Eliminate a few `extern const` items

### DIFF
--- a/boot/bootutil/include/bootutil/bootutil.h
+++ b/boot/bootutil/include/bootutil/bootutil.h
@@ -50,8 +50,7 @@ extern "C" {
 /** Swapping encountered an unrecoverable error */
 #define BOOT_SWAP_TYPE_PANIC    0xff
 
-#define MAX_FLASH_ALIGN         8
-extern const uint32_t BOOT_MAX_ALIGN;
+#define BOOT_MAX_ALIGN          8
 
 struct image_header;
 /**
@@ -75,11 +74,11 @@ struct boot_rsp {
  */
 struct image_trailer {
     uint8_t swap_type;
-    uint8_t pad1[MAX_FLASH_ALIGN - 1];
+    uint8_t pad1[BOOT_MAX_ALIGN - 1];
     uint8_t copy_done;
-    uint8_t pad2[MAX_FLASH_ALIGN - 1];
+    uint8_t pad2[BOOT_MAX_ALIGN - 1];
     uint8_t image_ok;
-    uint8_t pad3[MAX_FLASH_ALIGN - 1];
+    uint8_t pad3[BOOT_MAX_ALIGN - 1];
     uint8_t magic[16];
 };
 

--- a/boot/bootutil/src/bootutil_misc.c
+++ b/boot/bootutil/src/bootutil_misc.c
@@ -52,8 +52,6 @@ const uint32_t boot_img_magic[] = {
 #define BOOT_MAGIC_ARR_SZ \
     (sizeof boot_img_magic / sizeof boot_img_magic[0])
 
-const uint32_t BOOT_MAGIC_SZ = sizeof boot_img_magic;
-
 struct boot_swap_table {
     uint8_t magic_primary_slot;
     uint8_t magic_secondary_slot;

--- a/boot/bootutil/src/bootutil_misc.c
+++ b/boot/bootutil/src/bootutil_misc.c
@@ -53,7 +53,6 @@ const uint32_t boot_img_magic[] = {
     (sizeof boot_img_magic / sizeof boot_img_magic[0])
 
 const uint32_t BOOT_MAGIC_SZ = sizeof boot_img_magic;
-const uint32_t BOOT_MAX_ALIGN = MAX_FLASH_ALIGN;
 
 struct boot_swap_table {
     uint8_t magic_primary_slot;

--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -185,7 +185,7 @@ _Static_assert(BOOT_IMAGE_NUMBER > 0, "Invalid value for BOOT_IMAGE_NUMBER");
 #define BOOT_STATUS_SOURCE_SCRATCH      1
 #define BOOT_STATUS_SOURCE_PRIMARY_SLOT 2
 
-extern const uint32_t BOOT_MAGIC_SZ;
+#define BOOT_MAGIC_SZ (sizeof boot_img_magic)
 
 /**
  * Compatibility shim for flash sector type.

--- a/sim/mcuboot-sys/csupport/run.c
+++ b/sim/mcuboot-sys/csupport/run.c
@@ -454,3 +454,8 @@ uint32_t boot_max_align(void)
 {
     return BOOT_MAX_ALIGN;
 }
+
+uint32_t boot_magic_sz(void)
+{
+    return BOOT_MAGIC_SZ;
+}

--- a/sim/mcuboot-sys/csupport/run.c
+++ b/sim/mcuboot-sys/csupport/run.c
@@ -449,3 +449,8 @@ void sim_assert(int x, const char *assertion, const char *file, unsigned int lin
         }
     }
 }
+
+uint32_t boot_max_align(void)
+{
+    return BOOT_MAX_ALIGN;
+}

--- a/sim/mcuboot-sys/src/c.rs
+++ b/sim/mcuboot-sys/src/c.rs
@@ -45,7 +45,7 @@ pub fn boot_magic_sz() -> usize {
 }
 
 pub fn boot_max_align() -> usize {
-    unsafe { raw::BOOT_MAX_ALIGN as usize }
+    unsafe { raw::boot_max_align() as usize }
 }
 
 pub fn rsa_oaep_encrypt(pubkey: &[u8], seckey: &[u8]) -> Result<[u8; 256], &'static str> {
@@ -84,7 +84,7 @@ mod raw {
         pub fn boot_trailer_sz(min_write_sz: u8) -> u32;
 
         pub static BOOT_MAGIC_SZ: u32;
-        pub static BOOT_MAX_ALIGN: u32;
+        pub fn boot_max_align() -> u32;
 
         pub fn rsa_oaep_encrypt_(pubkey: *const u8, pubkey_len: libc::c_uint,
                                  seckey: *const u8, seckey_len: libc::c_uint,

--- a/sim/mcuboot-sys/src/c.rs
+++ b/sim/mcuboot-sys/src/c.rs
@@ -41,7 +41,7 @@ pub fn boot_trailer_sz(align: u8) -> u32 {
 }
 
 pub fn boot_magic_sz() -> usize {
-    unsafe { raw::BOOT_MAGIC_SZ as usize }
+    unsafe { raw::boot_magic_sz() as usize }
 }
 
 pub fn boot_max_align() -> usize {
@@ -83,7 +83,7 @@ mod raw {
 
         pub fn boot_trailer_sz(min_write_sz: u8) -> u32;
 
-        pub static BOOT_MAGIC_SZ: u32;
+        pub fn boot_magic_sz() -> u32;
         pub fn boot_max_align() -> u32;
 
         pub fn rsa_oaep_encrypt_(pubkey: *const u8, pubkey_len: libc::c_uint,


### PR DESCRIPTION
Values of type `extern const` generate possibly an extra load (depending on the value), but also make it possible to introduce VLA (variable length arrays) into the code. These changes eliminate two of these consts that really should just be #defines. Instead of the simulator accessing them directly, provide an accessor function to make the constant value available.