### PR TITLE
imgtool: add mailing list email to setup

### DIFF
--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -5,7 +5,7 @@ setuptools.setup(
     name="imgtool",
     version=imgtool_version,
     author="The MCUboot commiters",
-    author_email="None",
+    author_email="dev-mcuboot@lists.runtime.co",
     description=("MCUboot's image signing and key management"),
     license="Apache Software License",
     url="http://github.com/JuulLabs-OSS/mcuboot",


### PR DESCRIPTION
Seems like pypi.org is not accepting "None" for email anymore, so this just adds the mailing list in case someone needs to contact the project.