### PR TITLE
Fix overflow in offset variable

### DIFF
--- a/boot/bootutil/include/bootutil/image.h
+++ b/boot/bootutil/include/bootutil/image.h
@@ -151,7 +151,7 @@ struct image_tlv_iter {
     const struct flash_area *fap;
     uint8_t type;
     bool prot;
-    uint16_t prot_end;
+    uint32_t prot_end;
     uint32_t tlv_off;
     uint32_t tlv_end;
 };


### PR DESCRIPTION
In the TLV iterator code a variable is used to save the offset in flash where the protected TLVs end; this was declared as `uint16_t` and could easily overflow so fix it by updating the type to `uint32_t`.