### PR TITLE
imgtool: add `erased-val` option, add full trailer to HEX files

### DIFF
--- a/scripts/imgtool/__init__.py
+++ b/scripts/imgtool/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-imgtool_version = "1.4.0"
+imgtool_version = "1.5.0a1"

--- a/scripts/imgtool/image.py
+++ b/scripts/imgtool/image.py
@@ -179,9 +179,13 @@ class Image():
                 self.base_addr = hex_addr
             h.frombytes(bytes=self.payload, offset=self.base_addr)
             if self.pad:
-                magic_addr = (self.base_addr + self.slot_size) - \
-                    len(boot_magic)
-                h.puts(magic_addr, boot_magic)
+                trailer_size = self._trailer_size(self.align, self.max_sectors,
+                                                  self.overwrite_only,
+                                                  self.enckey)
+                trailer_addr = (self.base_addr + self.slot_size) - trailer_size
+                padding = bytes([self.erased_val] *
+                                (trailer_size - len(boot_magic))) + boot_magic
+                h.puts(trailer_addr, padding)
             h.tofile(path, 'hex')
         else:
             if self.pad:

--- a/scripts/imgtool/image.py
+++ b/scripts/imgtool/image.py
@@ -344,7 +344,7 @@ class Image():
             trailer = m * 3 * write_size  # status area
             if enckey is not None:
                 trailer += 16 * 2  # encryption keys
-            trailer += MAX_ALIGN * 4  # magic_ok/copy_done/swap_info/swap_size
+            trailer += MAX_ALIGN * 4  # image_ok/copy_done/swap_info/swap_size
             trailer += magic_size
             return trailer
 

--- a/scripts/imgtool/main.py
+++ b/scripts/imgtool/main.py
@@ -182,6 +182,9 @@ class BasedIntParamType(click.ParamType):
 
 @click.argument('outfile')
 @click.argument('infile')
+@click.option('-R', '--erased-val', type=click.Choice(['0', '0xff']),
+              required=False,
+              help='The value that is read back from erased flash.')
 @click.option('-x', '--hex-addr', type=BasedIntParamType(), required=False,
               help='Adjust address in hex output file.')
 @click.option('-L', '--load-addr', type=BasedIntParamType(), required=False,
@@ -214,12 +217,12 @@ class BasedIntParamType(click.ParamType):
                .hex extension, otherwise binary format is used''')
 def sign(key, align, version, header_size, pad_header, slot_size, pad,
          max_sectors, overwrite_only, endian, encrypt, infile, outfile,
-         dependencies, load_addr, hex_addr):
+         dependencies, load_addr, hex_addr, erased_val):
     img = image.Image(version=decode_version(version), header_size=header_size,
                       pad_header=pad_header, pad=pad, align=int(align),
                       slot_size=slot_size, max_sectors=max_sectors,
                       overwrite_only=overwrite_only, endian=endian,
-                      load_addr=load_addr)
+                      load_addr=load_addr, erased_val=erased_val)
     img.load(infile)
     key = load_key(key) if key else None
     enckey = load_key(encrypt) if encrypt else None


### PR DESCRIPTION
This was not tested in HW; also can wait for after 1.4.0.