### PR TITLE
mynewt: allow overriding the startup routine

### DIFF
--- a/boot/mynewt/src/main.c
+++ b/boot/mynewt/src/main.c
@@ -46,6 +46,10 @@
 #include "bootutil/bootutil.h"
 #include "bootutil/bootutil_log.h"
 
+#if MYNEWT_VAL(BOOT_CUSTOM_START)
+void boot_custom_start(uintptr_t flash_base, struct boot_rsp *rsp);
+#endif
+
 #if defined(MCUBOOT_SERIAL)
 #define BOOT_SERIAL_REPORT_DUR  \
     (MYNEWT_VAL(OS_CPUTIME_FREQ) / MYNEWT_VAL(BOOT_SERIAL_REPORT_FREQ))
@@ -239,8 +243,12 @@ main(void)
     rc = flash_device_base(rsp.br_flash_dev_id, &flash_base);
     assert(rc == 0);
 
+#if MYNEWT_VAL(BOOT_CUSTOM_START)
+    boot_custom_start(flash_base, &rsp);
+#else
     hal_system_start((void *)(flash_base + rsp.br_image_off +
                               rsp.br_hdr->ih_hdr_size));
+#endif
 
     return 0;
 }

--- a/boot/mynewt/syscfg.yml
+++ b/boot/mynewt/syscfg.yml
@@ -25,6 +25,9 @@ syscfg.defs:
     BOOT_SERIAL:
         description: 'Support image upgrade over serial within bootloader'
         value: 0
+    BOOT_CUSTOM_START:
+        description: 'Override hal_system_start with a custom start routine'
+        value: 0
 
 syscfg.vals:
     SYSINIT_CONSTRAIN_INIT: 0


### PR DESCRIPTION
Add a new Mynewt option that allows for overriding the default `hal_system_start` routine; this allows for startup customizations required by some BSPs.

There's also a commit with some example custom code that will be dropped before merge!