### PR TITLE
mynewt: Make cflags consistent for if or ifdef usage

### DIFF
--- a/boot/boot_serial/test/pkg.yml
+++ b/boot/boot_serial/test/pkg.yml
@@ -32,4 +32,4 @@ pkg.deps.SELFTEST:
     - "@apache-mynewt-core/sys/console/stub"
 
 pkg.cflags:
-    - '-DMCUBOOT_MYNEWT'
+    - '-DMCUBOOT_MYNEWT=1'

--- a/boot/bootutil/pkg.yml
+++ b/boot/bootutil/pkg.yml
@@ -29,7 +29,7 @@ pkg.apis:
     - bootloader
 
 pkg.cflags:
-    - "-DMCUBOOT_MYNEWT"
+    - "-DMCUBOOT_MYNEWT=1"
 
 pkg.cflags.BOOTUTIL_USE_MBED_TLS:
     - '-DMBEDTLS_USER_CONFIG_FILE="mbedtls/config_mynewt.h"'

--- a/boot/mynewt/pkg.yml
+++ b/boot/mynewt/pkg.yml
@@ -26,7 +26,7 @@ pkg.keywords:
     - loader
 
 pkg.cflags:
-    - "-DMCUBOOT_MYNEWT"
+    - "-DMCUBOOT_MYNEWT=1"
 
 pkg.deps:
     - "@mcuboot/boot/mynewt/mcuboot_config"


### PR DESCRIPTION
This patch changes the cflag entry for MCUBOOT_MYNEWT to make it
consistent when using #if or #ifdef.

Signed-off-by: Andy Gross <andy.gross@juul.com>