### PR TITLE
imgtool: fix header padding value check

### DIFF
--- a/scripts/imgtool/image.py
+++ b/scripts/imgtool/image.py
@@ -197,7 +197,7 @@ class Image():
         """Perform some sanity checking of the image."""
         # If there is a header requested, make sure that the image
         # starts with all zeros.
-        if self.header_size > 0:
+        if self.header_size > 0 and not self.pad_header:
             if any(v != 0 for v in self.payload[0:self.header_size]):
                 raise Exception("Padding requested, but image does not start with zeros")
         if self.slot_size > 0:


### PR DESCRIPTION
Commit 9117fded476768b458253902a7d9c87e3663802a added support for supplying an `--erased-val`, which defaults to 0xff. When padding a header, the checks were still validating against 0, which is the value used for padding by the Zephyr build system. Now when the user passes `--pad-header` this check is skipped (we already know the contents).

