### PR TITLE
Fix up typos

### DIFF
--- a/boot/bootutil/src/bootutil_misc.c
+++ b/boot/bootutil/src/bootutil_misc.c
@@ -310,7 +310,7 @@ boot_read_swap_state_by_id(int flash_area_id, struct boot_swap_state *state)
  * This functions tries to locate the status area after an aborted swap,
  * by looking for the magic in the possible locations.
  *
- * If the magic is sucessfully found, a flash_area * is returned and it
+ * If the magic is successfully found, a flash_area * is returned and it
  * is the responsibility of the called to close it.
  *
  * @returns 0 on success, -1 on errors

--- a/boot/bootutil/src/image_rsa.c
+++ b/boot/bootutil/src/image_rsa.c
@@ -191,7 +191,7 @@ bootutil_cmp_rsasig(mbedtls_rsa_context *ctx, uint8_t *hash, uint32_t hlen,
      * The salt length is not known at this point.
      */
 
-    /* Step 4.  If the rightmost octect of EM does have the value
+    /* Step 4.  If the rightmost octet of EM does have the value
      * 0xbc, output inconsistent and stop.
      */
     if (em[PSS_EMLEN - 1] != 0xbc) {

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -383,7 +383,7 @@ boot_write_sz(struct boot_loader_state *state)
 }
 
 /*
- * Slots are compatible when all sectors that store upto to size of the image
+ * Slots are compatible when all sectors that store up to to size of the image
  * round up to sector size, in both slot's are able to fit in the scratch
  * area, and have sizes that are a multiple of each other (powers of two
  * presumably!).
@@ -915,7 +915,7 @@ boot_check_header_erased(struct boot_loader_state *state, int slot)
  * Check that there is a valid image in a slot
  *
  * @returns
- *         0 if image was succesfully validated
+ *         0 if image was successfully validated
  *         1 if no bootloable image was found
  *         -1 on any errors
  */

--- a/boot/bootutil/src/tlv.c
+++ b/boot/bootutil/src/tlv.c
@@ -29,7 +29,7 @@
  * @param type Type of TLV to look for
  * @param prot true if TLV has to be stored in the protected area, false otherwise
  *
- * @returns 0 if the TLV iterator was succesfully started
+ * @returns 0 if the TLV iterator was successfully started
  *          -1 on errors
  */
 int

--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -127,7 +127,7 @@ config BOOT_UPGRADE_ONLY
 	  uses a much simpler code path.
 
 config BOOT_BOOTSTRAP
-	bool "Boostrap erased the primary slot from the secondary slot"
+	bool "Bootstrap erased the primary slot from the secondary slot"
 	default n
 	help
 	  If y, enables bootstraping support. Bootstrapping allows an erased

--- a/boot/zephyr/include/flash_map_backend/flash_map_backend.h
+++ b/boot/zephyr/include/flash_map_backend/flash_map_backend.h
@@ -77,7 +77,7 @@ int flash_area_id_to_multi_image_slot(int image_index, int area_id);
 int flash_area_sector_from_off(off_t off, struct flash_sector *sector);
 
 /*
- * Returns the value expected to be read when accesing any erased
+ * Returns the value expected to be read when accessing any erased
  * flash byte.
  */
 uint8_t flash_area_erased_val(const struct flash_area *fap);

--- a/ci/sim_run.sh
+++ b/ci/sim_run.sh
@@ -17,7 +17,7 @@ pushd sim
 EXIT_CODE=0
 
 if [[ ! -z $SINGLE_FEATURES ]]; then
-  all_features="sig-rsa sig-ecdsa overwrite-only validate-primary-slot enc-rsa enc-kw boostrap"
+  all_features="sig-rsa sig-ecdsa overwrite-only validate-primary-slot enc-rsa enc-kw bootstrap"
 
   if [[ $SINGLE_FEATURES =~ "none" ]]; then
     echo "Running cargo with no features"

--- a/docs/encrypted_images.md
+++ b/docs/encrypted_images.md
@@ -42,7 +42,7 @@ It does not protect against the possibility of attaching a JTAG and
 reading the internal flash memory, or using some attack vector that
 enables dumping the internal flash in any way.
 
-Since decrypting requires a private key (or secret if using symetric
+Since decrypting requires a private key (or secret if using symmetric
 crypto) to reside inside the device, it is the responsibility of the
 device manufacturer to guarantee that this key is already in the device
 and not possible to extract.

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -4,7 +4,7 @@ from imgtool import imgtool_version
 setuptools.setup(
     name="imgtool",
     version=imgtool_version,
-    author="The MCUboot commiters",
+    author="The MCUboot committers",
     author_email="dev-mcuboot@lists.runtime.co",
     description=("MCUboot's image signing and key management"),
     license="Apache Software License",

--- a/sim/simflash/src/lib.rs
+++ b/sim/simflash/src/lib.rs
@@ -83,7 +83,7 @@ fn esimulatedwrite<T: AsRef<str>>(message: T) -> FlashError {
 }
 
 /// An emulated flash device.  It is represented as a block of bytes, and a list of the sector
-/// mapings.
+/// mappings.
 #[derive(Clone)]
 pub struct SimFlash {
     data: Vec<u8>,


### PR DESCRIPTION
Ran automated checker for common typos [1]. Most of these changes have
no functional change *except* for `./ci/sim_run.sh` where, previously
the `bootstrap` feature wasn't being selected properly.

I didn't touch anything in the `./ext/` folder as anything in there
should probably be fixed in the upstream repo.

[1] https://github.com/codespell-project/codespell

Signed-off-by: Sam Bristow <sam@bristow.nz>