### PR TITLE
imgtool: ed25519: add method to return raw bytes

### DIFF
--- a/scripts/imgtool/keys/ed25519.py
+++ b/scripts/imgtool/keys/ed25519.py
@@ -32,6 +32,11 @@ class Ed25519Public(KeyClass):
                 encoding=serialization.Encoding.DER,
                 format=serialization.PublicFormat.SubjectPublicKeyInfo)
 
+    def get_public_raw_bytes(self):
+        return self._get_public().public_bytes(
+                encoding=serialization.Encoding.Raw,
+                format=serialization.PublicFormat.Raw)
+
     def export_private(self, path, passwd=None):
         self._unsupported('export_private')
 


### PR DESCRIPTION
Add a method to return the 32 bytes Public Key in
Raw Encoding and Public Raw format.
The existing `get_public_bytes` returns DER format which is 44 bytes long.

This enables the clients to use the API instead of
doing a
```
    string_stream = (
        key._get_public()
        .public_bytes(
            encoding=serialization.Encoding.Raw, format=serialization.PublicFormat.Raw
        )
        .hex()
    )
```

Signed-off-by: Naveen Kaje <naveen.kaje@juul.com>