### PR TITLE
Bugfix: nRF Cryptocell not being disabled

### DIFF
--- a/ext/nrf/cc310_glue.h
+++ b/ext/nrf/cc310_glue.h
@@ -36,7 +36,7 @@ static inline void nrf_cc310_enable(void)
 
 static inline void nrf_cc310_disable(void)
 {
-    NRF_CRYPTOCELL->ENABLE=1;
+    NRF_CRYPTOCELL->ENABLE=0;
 }
 
 /* Enable and disable cc310 to reduce power consumption */


### PR DESCRIPTION
Copy paste bug in cc310 glue layer for nRF where disable does not set
the enable register to 0. Thanks to @solsbarry for pointing this out.

Fixes: #586

Signed-off-by: sigvartmh <sigvart.m@gmail.com>