### PR TITLE
Test overwrite mode with large-write align devices

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,11 +23,11 @@ matrix:
     # separated by ',' and each list of values is run sequentially in the
     # defined order.
     - os: linux
-      env: MULTI_FEATURES="sig-rsa overwrite-only,sig-ecdsa overwrite-only,multiimage overwrite-only" TEST=sim
+      env: MULTI_FEATURES="sig-rsa overwrite-only large-write,sig-ecdsa overwrite-only large-write,multiimage overwrite-only large-write" TEST=sim
     - os: linux
       env: MULTI_FEATURES="sig-rsa validate-primary-slot,sig-ecdsa validate-primary-slot,sig-rsa multiimage validate-primary-slot" TEST=sim
     - os: linux
-      env: MULTI_FEATURES="enc-kw overwrite-only,enc-rsa overwrite-only" TEST=sim
+      env: MULTI_FEATURES="enc-kw overwrite-only large-write,enc-rsa overwrite-only large-write" TEST=sim
     - os: linux
       env: MULTI_FEATURES="sig-rsa enc-rsa validate-primary-slot" TEST=sim
     - os: linux
@@ -35,7 +35,7 @@ matrix:
     - os: linux
       env: MULTI_FEATURES="sig-ecdsa enc-kw validate-primary-slot" TEST=sim
     - os: linux
-      env: MULTI_FEATURES="sig-rsa validate-primary-slot overwrite-only,sig-ecdsa enc-ec256 validate-primary-slot" TEST=sim
+      env: MULTI_FEATURES="sig-rsa validate-primary-slot overwrite-only large-write,sig-ecdsa enc-ec256 validate-primary-slot" TEST=sim
 
     - os: linux
       language: go

--- a/boot/bootutil/src/bootutil_misc.c
+++ b/boot/bootutil/src/bootutil_misc.c
@@ -148,7 +148,7 @@ boot_magic_compatible_check(uint8_t tbl_val, uint8_t val)
 }
 
 uint32_t
-boot_trailer_sz(uint8_t min_write_sz)
+boot_trailer_sz(uint32_t min_write_sz)
 {
     return /* state for all sectors */
            BOOT_STATUS_MAX_ENTRIES * BOOT_STATUS_STATE_COUNT * min_write_sz +

--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -214,7 +214,7 @@ struct boot_loader_state {
     } scratch;
 
     uint8_t swap_type[BOOT_IMAGE_NUMBER];
-    uint8_t write_sz;
+    uint32_t write_sz;
 
 #if defined(MCUBOOT_ENC_IMAGES)
     struct enc_key_data enc[BOOT_IMAGE_NUMBER][BOOT_NUM_SLOTS];
@@ -229,7 +229,7 @@ int bootutil_verify_sig(uint8_t *hash, uint32_t hlen, uint8_t *sig,
                         size_t slen, uint8_t key_id);
 
 int boot_magic_compatible_check(uint8_t tbl_val, uint8_t val);
-uint32_t boot_trailer_sz(uint8_t min_write_sz);
+uint32_t boot_trailer_sz(uint32_t min_write_sz);
 int boot_status_entries(int image_index, const struct flash_area *fap);
 uint32_t boot_status_off(const struct flash_area *fap);
 uint32_t boot_swap_info_off(const struct flash_area *fap);

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -363,11 +363,11 @@ boot_read_image_headers(struct boot_loader_state *state, bool require_all)
     return 0;
 }
 
-static uint8_t
+static uint32_t
 boot_write_sz(struct boot_loader_state *state)
 {
-    uint8_t elem_sz;
-    uint8_t align;
+    uint32_t elem_sz;
+    uint32_t align;
 
     /* Figure out what size to write update status update as.  The size depends
      * on what the minimum write size is for scratch area, active image slot.

--- a/sim/Cargo.toml
+++ b/sim/Cargo.toml
@@ -18,6 +18,7 @@ enc-kw = ["mcuboot-sys/enc-kw"]
 enc-ec256 = ["mcuboot-sys/enc-ec256"]
 bootstrap = ["mcuboot-sys/bootstrap"]
 multiimage = ["mcuboot-sys/multiimage"]
+large-write = []
 
 [dependencies]
 byteorder = "1.3"

--- a/sim/src/image.rs
+++ b/sim/src/image.rs
@@ -1490,6 +1490,13 @@ pub fn mark_upgrade(flash: &mut SimMultiFlash, slot: &SlotInfo) {
 /// Writes the image_ok flag which, guess what, tells the bootloader
 /// the this image is ok (not a test, and no revert is to be performed).
 fn mark_permanent_upgrade(flash: &mut SimMultiFlash, slot: &SlotInfo) {
+    // Overwrite mode always is permanent, and only the magic is used in
+    // the trailer.  To avoid problems with large write sizes, don't try to
+    // set anything in this case.
+    if Caps::OverwriteUpgrade.present() {
+        return;
+    }
+
     let dev = flash.get_mut(&slot.dev_id).unwrap();
     let mut ok = [dev.erased_val(); 8];
     ok[0] = 1u8;

--- a/sim/src/image.rs
+++ b/sim/src/image.rs
@@ -1338,7 +1338,7 @@ fn verify_trailer(flash: &SimMultiFlash, slot: &SlotInfo,
 
     failed |= match magic {
         Some(v) => {
-            if v == 1 && &copy[24..] != MAGIC.unwrap() {
+            if v == 1 && &copy[24..] != MAGIC {
                 warn!("\"magic\" mismatch at {:#x}", offset);
                 true
             } else if v == 3 {
@@ -1468,10 +1468,10 @@ pub struct SlotInfo {
     pub dev_id: u8,
 }
 
-const MAGIC: Option<&[u8]> = Some(&[0x77, 0xc2, 0x95, 0xf3,
-                                    0x60, 0xd2, 0xef, 0x7f,
-                                    0x35, 0x52, 0x50, 0x0f,
-                                    0x2c, 0xb6, 0x79, 0x80]);
+const MAGIC: &[u8] = &[0x77, 0xc2, 0x95, 0xf3,
+                       0x60, 0xd2, 0xef, 0x7f,
+                       0x35, 0x52, 0x50, 0x0f,
+                       0x2c, 0xb6, 0x79, 0x80];
 
 // Replicates defines found in bootutil.h
 const BOOT_MAGIC_GOOD: Option<u8> = Some(1);
@@ -1484,7 +1484,7 @@ const BOOT_FLAG_UNSET: Option<u8> = Some(3);
 pub fn mark_upgrade(flash: &mut SimMultiFlash, slot: &SlotInfo) {
     let dev = flash.get_mut(&slot.dev_id).unwrap();
     let offset = slot.trailer_off + c::boot_max_align() * 4;
-    dev.write(offset, MAGIC.unwrap()).unwrap();
+    dev.write(offset, MAGIC).unwrap();
 }
 
 /// Writes the image_ok flag which, guess what, tells the bootloader

--- a/sim/src/image.rs
+++ b/sim/src/image.rs
@@ -84,7 +84,7 @@ impl ImagesBuilder {
     /// Construct a new image builder for the given device.  Returns
     /// Some(builder) if is possible to test this configuration, or None if
     /// not possible (for example, if there aren't enough image slots).
-    pub fn new(device: DeviceName, align: u8, erased_val: u8) -> Option<Self> {
+    pub fn new(device: DeviceName, align: usize, erased_val: u8) -> Option<Self> {
         let (flash, areadesc) = Self::make_device(device, align, erased_val);
 
         let num_images = Caps::get_num_images();
@@ -227,7 +227,7 @@ impl ImagesBuilder {
     }
 
     /// Build the Flash and area descriptor for a given device.
-    pub fn make_device(device: DeviceName, align: u8, erased_val: u8) -> (SimMultiFlash, AreaDesc) {
+    pub fn make_device(device: DeviceName, align: usize, erased_val: u8) -> (SimMultiFlash, AreaDesc) {
         match device {
             DeviceName::Stm32f4 => {
                 // STM style flash.  Large sectors, with a large scratch area.

--- a/sim/src/lib.rs
+++ b/sim/src/lib.rs
@@ -80,7 +80,7 @@ impl fmt::Display for DeviceName {
 }
 
 #[derive(Debug)]
-struct AlignArg(u8);
+struct AlignArg(usize);
 
 struct AlignArgVisitor;
 
@@ -91,11 +91,11 @@ impl<'de> serde::de::Visitor<'de> for AlignArgVisitor {
         formatter.write_str("1, 2, 4 or 8")
     }
 
-    fn visit_u8<E>(self, n: u8) -> Result<Self::Value, E>
+    fn visit_u32<E>(self, n: u32) -> Result<Self::Value, E>
         where E: serde::de::Error
     {
         Ok(match n {
-            1 | 2 | 4 | 8 => AlignArg(n),
+            1 | 2 | 4 | 8 => AlignArg(n as usize),
             n => {
                 let err = format!("Could not deserialize '{}' as alignment", n);
                 return Err(E::custom(err));
@@ -169,7 +169,7 @@ impl RunStatus {
         }
     }
 
-    pub fn run_single(&mut self, device: DeviceName, align: u8, erased_val: u8) {
+    pub fn run_single(&mut self, device: DeviceName, align: usize, erased_val: u8) {
         warn!("Running on device {} with alignment {}", device, align);
 
         let run = match ImagesBuilder::new(device, align, erased_val) {


### PR DESCRIPTION
Some (largely simulator) changes to test the configuration with overwrite-only enabled on devices with large write sizes. The flash API still returns a `uint8_t` for the alignment, so this value will be bogus for devices with 512-byte alignment, but these tests ensure that the value isn't actually used in the overwrite-only case.

There is one change that changes the size of the type where the alignment is stored within the boot code. Changing this would allow a particular platform to define `flash_area_align()` to return a larger type, and not immediately discard the value.

Supporting larger write alignment with swap will be significantly more work, and is not addressed by the PR.