### PR TITLE
sim: add randomly generated image encryption keys

### DIFF
--- a/boot/bootutil/src/bootutil_misc.c
+++ b/boot/bootutil/src/bootutil_misc.c
@@ -321,8 +321,8 @@ boot_find_status(int image_index, const struct flash_area **fap)
     uint32_t magic[BOOT_MAGIC_ARR_SZ];
     uint32_t off;
     uint8_t areas[2] = {
-        FLASH_AREA_IMAGE_PRIMARY(image_index),
         FLASH_AREA_IMAGE_SCRATCH,
+        FLASH_AREA_IMAGE_PRIMARY(image_index),
     };
     unsigned int i;
     int rc;


### PR DESCRIPTION
Removes the hard-coded image encryption keys, and updates with keys generated randomly before use. This tests the correct behavior of how ephemeral keys should be used when generating new images.