### PR TITLE
zephyr: restore removed #endif in target.h

### DIFF
--- a/boot/zephyr/include/target.h
+++ b/boot/zephyr/include/target.h
@@ -23,6 +23,8 @@
 
 #define FLASH_ALIGN FLASH_WRITE_BLOCK_SIZE
 
+#endif /* !defined(MCUBOOT_TARGET_CONFIG) */
+
 /*
  * Sanity check the target support.
  */


### PR DESCRIPTION
8accafd5c7e8d19c832574993ffb664f69fa345e has removed `#endif` statement belonging to `#if` unrelated to removed code block, causing compilation error:
```
In file included from /.../mcuboot/boot/zephyr/main.c:26:
/.../mcuboot/boot/zephyr/include/target.h:8: error: unterminated #ifndef
 #ifndef H_TARGETS_TARGET_

[35/229] Building C object CMakeFiles/app.dir/.../mcuboot/boot/bootutil/src/image_rsa.c.obj
ninja: build stopped: subcommand failed.
ERROR: command exited with status 1: /usr/bin/cmake --build /.../mcuboot/build
```

Restore it.