### PR TITLE
zephyr: Fix build problem with missing overlay

### DIFF
--- a/boot/zephyr/dts.overlay
+++ b/boot/zephyr/dts.overlay
@@ -1,0 +1,8 @@
+/*
+ * MCUboot should always be built in the boot partition.
+ */
+/ {
+	chosen {
+		zephyr,code-partition = &boot_partition;
+	};
+};


### PR DESCRIPTION
The commit:

commit 0e3fa72df4849eb42c99efb34b8617046c2e33cb
Author: Martí Bolívar <marti.bolivar@nordicsemi.no>
Date:   Tue Oct 22 14:39:33 2019 -0600

    zephyr: Fix board logic

Mistakenly removed the dts.overlay file, despite it still being
referenced.  What I believe it intended to remove was the ifdef that is
no longer needed, but we still reference this overlay, and still need it
in order to put mcuboot into the boot partition of flash.

Signed-off-by: David Brown <david.brown@linaro.org>