### PR TITLE
zephyr: restore device tree overlay

### DIFF
--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -6,6 +6,19 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
+# Add a common dts overlay necessary to ensure mcuboot is linked into,
+# and fits inside, the boot partition. (If the user specified a
+# DTC_OVERLAY_FILE on the CMake command line, we need to append onto
+# the list).
+if(DTC_OVERLAY_FILE)
+  set(DTC_OVERLAY_FILE
+    "${DTC_OVERLAY_FILE} ${CMAKE_CURRENT_LIST_DIR}/dts.overlay"
+    CACHE STRING "" FORCE
+    )
+else()
+  set(DTC_OVERLAY_FILE ${CMAKE_CURRENT_LIST_DIR}/dts.overlay)
+endif()
+
 # Enable Zephyr runner options which request mass erase if so
 # configured.
 #

--- a/boot/zephyr/dts.overlay
+++ b/boot/zephyr/dts.overlay
@@ -1,0 +1,5 @@
+/ {
+	chosen {
+		zephyr,code-partition = &boot_partition;
+	};
+};


### PR DESCRIPTION
0e3fa72df4849eb42c99efb34b8617046c2e33cb removed device tree overlay that configures Zephyr to link mcuboot at the beginning of the flash, and CMake variable that pointed to it (required for Zephyr). This resulted in mcuboot not being linked at some offset, rendering it unable to boot. Restore overlay and required code.

Without it, Zephyr will use `zephyr,code-partition` configuration from board device tree that usually points to the `slot0_partition`. This behaviour is due to the [CONFIG_USE_CODE_PARTITION](https://docs.zephyrproject.org/latest/reference/kconfig/CONFIG_USE_CODE_PARTITION.html) being used in MCUboot's configuration for Zephyr.

Fixes #601.

Signed-off-by: Sergey Koziakov <dya.eshshmai@gmail.com>