### PR TITLE
sim: Remove some extraneous print

### DIFF
--- a/sim/src/image.rs
+++ b/sim/src/image.rs
@@ -1545,12 +1545,10 @@ pub fn show_sizes() {
 
 #[cfg(not(feature = "large-write"))]
 fn test_alignments() -> &'static [usize] {
-    println!("Not large write");
     &[1, 2, 4, 8]
 }
 
 #[cfg(feature = "large-write")]
 fn test_alignments() -> &'static [usize] {
-    println!("Large write test: {:?}", cfg!(feature = "large-write"));
     &[1, 2, 4, 8, 128, 512]
 }


### PR DESCRIPTION
These were added during development to make sure conditional compilation
was working.  Now, they just cause excess messages to be printed.
Remove them.

Signed-off-by: David Brown <david.brown@linaro.org>