### PR TITLE
Make TLVs 16 bits

### DIFF
--- a/boot/bootutil/include/bootutil/image.h
+++ b/boot/bootutil/include/bootutil/image.h
@@ -84,7 +84,7 @@ struct flash_area;
 #define IMAGE_TLV_ENC_KW128         0x31   /* Key encrypted with AES-KW-128 */
 #define IMAGE_TLV_ENC_EC256         0x32   /* Key encrypted with ECIES-EC256 */
 #define IMAGE_TLV_DEPENDENCY        0x40   /* Image depends on other image */
-#define IMAGE_TLV_ANY               0xff   /* Used to iterate over all TLV */
+#define IMAGE_TLV_ANY               0xffff /* Used to iterate over all TLV */
 
 struct image_version {
     uint8_t iv_major;
@@ -123,8 +123,7 @@ struct image_tlv_info {
 
 /** Image trailer TLV format. All fields in little endian. */
 struct image_tlv {
-    uint8_t  it_type;   /* IMAGE_TLV_[...]. */
-    uint8_t  _pad;
+    uint16_t it_type;   /* IMAGE_TLV_[...]. */
     uint16_t it_len;    /* Data length (not including TLV header). */
 };
 
@@ -150,7 +149,7 @@ int bootutil_img_validate(struct enc_key_data *enc_state, int image_index,
 struct image_tlv_iter {
     const struct image_header *hdr;
     const struct flash_area *fap;
-    uint8_t type;
+    uint16_t type;
     bool prot;
     uint32_t prot_end;
     uint32_t tlv_off;
@@ -159,10 +158,10 @@ struct image_tlv_iter {
 
 int bootutil_tlv_iter_begin(struct image_tlv_iter *it,
                             const struct image_header *hdr,
-                            const struct flash_area *fap, uint8_t type,
+                            const struct flash_area *fap, uint16_t type,
                             bool prot);
 int bootutil_tlv_iter_next(struct image_tlv_iter *it, uint32_t *off,
-                           uint16_t *len, uint8_t *type);
+                           uint16_t *len, uint16_t *type);
 
 #ifdef __cplusplus
 }

--- a/boot/bootutil/src/image_validate.c
+++ b/boot/bootutil/src/image_validate.c
@@ -212,7 +212,7 @@ bootutil_img_validate(struct enc_key_data *enc_state, int image_index,
 {
     uint32_t off;
     uint16_t len;
-    uint8_t type;
+    uint16_t type;
     int sha256_valid = 0;
 #ifdef EXPECTED_SIG_TLV
     int valid_signature = 0;

--- a/boot/bootutil/src/tlv.c
+++ b/boot/bootutil/src/tlv.c
@@ -34,7 +34,7 @@
  */
 int
 bootutil_tlv_iter_begin(struct image_tlv_iter *it, const struct image_header *hdr,
-                        const struct flash_area *fap, uint8_t type, bool prot)
+                        const struct flash_area *fap, uint16_t type, bool prot)
 {
     uint32_t off_;
     struct image_tlv_info info;
@@ -89,7 +89,7 @@ bootutil_tlv_iter_begin(struct image_tlv_iter *it, const struct image_header *hd
  */
 int
 bootutil_tlv_iter_next(struct image_tlv_iter *it, uint32_t *off, uint16_t *len,
-                       uint8_t *type)
+                       uint16_t *type)
 {
     struct image_tlv tlv;
     int rc;

--- a/sim/src/tlv.rs
+++ b/sim/src/tlv.rs
@@ -268,8 +268,7 @@ impl ManifestGen for TlvGen {
             protected_tlv.write_u16::<LittleEndian>(self.protect_size()).unwrap();
             for dep in &self.dependencies {
                 protected_tlv.write_u16::<LittleEndian>(TlvKinds::DEPENDENCY as u16).unwrap();
-                protected_tlv.push(12);
-                protected_tlv.push(0);
+                protected_tlv.write_u16::<LittleEndian>(12).unwrap();
 
                 // The dependency.
                 protected_tlv.push(dep.id);
@@ -309,8 +308,7 @@ impl ManifestGen for TlvGen {
 
             assert!(hash.len() == 32);
             result.write_u16::<LittleEndian>(TlvKinds::SHA256 as u16).unwrap();
-            result.push(32);
-            result.push(0);
+            result.write_u16::<LittleEndian>(32).unwrap();
             result.extend_from_slice(hash);
         }
 
@@ -329,8 +327,7 @@ impl ManifestGen for TlvGen {
 
             assert!(hash.len() == 32);
             result.write_u16::<LittleEndian>(TlvKinds::KEYHASH as u16).unwrap();
-            result.push(32);
-            result.push(0);
+            result.write_u16::<LittleEndian>(32).unwrap();
             result.extend_from_slice(hash);
 
             // For now assume PSS.
@@ -365,8 +362,7 @@ impl ManifestGen for TlvGen {
 
             assert!(keyhash.len() == 32);
             result.write_u16::<LittleEndian>(TlvKinds::KEYHASH as u16).unwrap();
-            result.push(32);
-            result.push(0);
+            result.write_u16::<LittleEndian>(32).unwrap();
             result.extend_from_slice(keyhash);
 
             let key_bytes = pem::parse(include_bytes!("../../root-ec-p256-pkcs8.pem").as_ref()).unwrap();
@@ -396,8 +392,7 @@ impl ManifestGen for TlvGen {
 
             assert!(keyhash.len() == 32);
             result.write_u16::<LittleEndian>(TlvKinds::KEYHASH as u16).unwrap();
-            result.push(32);
-            result.push(0);
+            result.write_u16::<LittleEndian>(32).unwrap();
             result.extend_from_slice(keyhash);
 
             let hash = digest::digest(&digest::SHA256, &sig_payload);
@@ -432,8 +427,7 @@ impl ManifestGen for TlvGen {
 
             assert!(encbuf.len() == 256);
             result.write_u16::<LittleEndian>(TlvKinds::ENCRSA2048 as u16).unwrap();
-            result.push(0);
-            result.push(1);
+            result.write_u16::<LittleEndian>(256).unwrap();
             result.extend_from_slice(&encbuf);
         }
 
@@ -450,8 +444,7 @@ impl ManifestGen for TlvGen {
 
             assert!(encbuf.len() == 24);
             result.write_u16::<LittleEndian>(TlvKinds::ENCKW128 as u16).unwrap();
-            result.push(24);
-            result.push(0);
+            result.write_u16::<LittleEndian>(24).unwrap();
             result.extend_from_slice(&encbuf);
         }
 
@@ -516,8 +509,7 @@ impl ManifestGen for TlvGen {
 
             assert!(buf.len() == 113);
             result.write_u16::<LittleEndian>(TlvKinds::ENCEC256 as u16).unwrap();
-            result.push(113);
-            result.push(0);
+            result.write_u16::<LittleEndian>(113).unwrap();
             result.extend_from_slice(&buf);
         }
 

--- a/sim/src/tlv.rs
+++ b/sim/src/tlv.rs
@@ -34,7 +34,7 @@ use aes_ctr::{
 };
 use mcuboot_sys::c;
 
-#[repr(u8)]
+#[repr(u16)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[allow(dead_code)] // TODO: For now
 pub enum TlvKinds {
@@ -267,8 +267,7 @@ impl ManifestGen for TlvGen {
             protected_tlv.push(0x69);
             protected_tlv.write_u16::<LittleEndian>(self.protect_size()).unwrap();
             for dep in &self.dependencies {
-                protected_tlv.push(TlvKinds::DEPENDENCY as u8);
-                protected_tlv.push(0);
+                protected_tlv.write_u16::<LittleEndian>(TlvKinds::DEPENDENCY as u16).unwrap();
                 protected_tlv.push(12);
                 protected_tlv.push(0);
 
@@ -309,8 +308,7 @@ impl ManifestGen for TlvGen {
             let hash = hash.as_ref();
 
             assert!(hash.len() == 32);
-            result.push(TlvKinds::SHA256 as u8);
-            result.push(0);
+            result.write_u16::<LittleEndian>(TlvKinds::SHA256 as u16).unwrap();
             result.push(32);
             result.push(0);
             result.extend_from_slice(hash);
@@ -330,8 +328,7 @@ impl ManifestGen for TlvGen {
             let hash = hash.as_ref();
 
             assert!(hash.len() == 32);
-            result.push(TlvKinds::KEYHASH as u8);
-            result.push(0);
+            result.write_u16::<LittleEndian>(TlvKinds::KEYHASH as u16).unwrap();
             result.push(32);
             result.push(0);
             result.extend_from_slice(hash);
@@ -354,11 +351,10 @@ impl ManifestGen for TlvGen {
             key_pair.sign(&RSA_PSS_SHA256, &rng, &sig_payload, &mut signature).unwrap();
 
             if is_rsa2048 {
-                result.push(TlvKinds::RSA2048 as u8);
+                result.write_u16::<LittleEndian>(TlvKinds::RSA2048 as u16).unwrap();
             } else {
-                result.push(TlvKinds::RSA3072 as u8);
+                result.write_u16::<LittleEndian>(TlvKinds::RSA3072 as u16).unwrap();
             }
-            result.push(0);
             result.write_u16::<LittleEndian>(signature.len() as u16).unwrap();
             result.extend_from_slice(&signature);
         }
@@ -368,8 +364,7 @@ impl ManifestGen for TlvGen {
             let keyhash = keyhash.as_ref();
 
             assert!(keyhash.len() == 32);
-            result.push(TlvKinds::KEYHASH as u8);
-            result.push(0);
+            result.write_u16::<LittleEndian>(TlvKinds::KEYHASH as u16).unwrap();
             result.push(32);
             result.push(0);
             result.extend_from_slice(keyhash);
@@ -382,8 +377,7 @@ impl ManifestGen for TlvGen {
             let rng = rand::SystemRandom::new();
             let signature = key_pair.sign(&rng, &sig_payload).unwrap();
 
-            result.push(TlvKinds::ECDSA256 as u8);
-            result.push(0);
+            result.write_u16::<LittleEndian>(TlvKinds::ECDSA256 as u16).unwrap();
 
             // signature must be padded...
             let mut signature = signature.as_ref().to_vec();
@@ -401,8 +395,7 @@ impl ManifestGen for TlvGen {
             let keyhash = keyhash.as_ref();
 
             assert!(keyhash.len() == 32);
-            result.push(TlvKinds::KEYHASH as u8);
-            result.push(0);
+            result.write_u16::<LittleEndian>(TlvKinds::KEYHASH as u16).unwrap();
             result.push(32);
             result.push(0);
             result.extend_from_slice(keyhash);
@@ -418,8 +411,7 @@ impl ManifestGen for TlvGen {
                 &key_bytes.contents[16..48], &ED25519_PUB_KEY[12..44]).unwrap();
             let signature = key_pair.sign(&hash);
 
-            result.push(TlvKinds::ED25519 as u8);
-            result.push(0);
+            result.write_u16::<LittleEndian>(TlvKinds::ED25519 as u16).unwrap();
 
             let signature = signature.as_ref().to_vec();
             result.write_u16::<LittleEndian>(signature.len() as u16).unwrap();
@@ -439,8 +431,7 @@ impl ManifestGen for TlvGen {
             };
 
             assert!(encbuf.len() == 256);
-            result.push(TlvKinds::ENCRSA2048 as u8);
-            result.push(0);
+            result.write_u16::<LittleEndian>(TlvKinds::ENCRSA2048 as u16).unwrap();
             result.push(0);
             result.push(1);
             result.extend_from_slice(&encbuf);
@@ -458,8 +449,7 @@ impl ManifestGen for TlvGen {
             };
 
             assert!(encbuf.len() == 24);
-            result.push(TlvKinds::ENCKW128 as u8);
-            result.push(0);
+            result.write_u16::<LittleEndian>(TlvKinds::ENCKW128 as u16).unwrap();
             result.push(24);
             result.push(0);
             result.extend_from_slice(&encbuf);
@@ -525,8 +515,7 @@ impl ManifestGen for TlvGen {
             buf.append(&mut cipherkey);
 
             assert!(buf.len() == 113);
-            result.push(TlvKinds::ENCEC256 as u8);
-            result.push(0);
+            result.write_u16::<LittleEndian>(TlvKinds::ENCEC256 as u16).unwrap();
             result.push(113);
             result.push(0);
             result.extend_from_slice(&buf);


### PR DESCRIPTION
Two changes, one for the code, and one for the simulator to make TLVs 16 bits. The format is compatible with the existing TLVs, so it isn't necessary to change imgtool until we want to support a TLV value larger than 8-bits (presumably that can happen with the user-defined TLV support).