### PR TITLE
sim: Actually test invalid signatures

### DIFF
--- a/sim/src/image.rs
+++ b/sim/src/image.rs
@@ -1149,12 +1149,10 @@ fn install_image(flash: &mut SimMultiFlash, slot: &SlotInfo, len: usize,
     }
 
     // Build the TLV itself.
-    let mut b_tlv = if bad_sig {
-        let good_sig = &mut tlv.make_tlv();
-        vec![0; good_sig.len()]
-    } else {
-        tlv.make_tlv()
-    };
+    if bad_sig {
+        tlv.corrupt_sig();
+    }
+    let mut b_tlv = tlv.make_tlv();
 
     let dev = flash.get_mut(&dev_id).unwrap();
 


### PR DESCRIPTION
Currently, the tests that appear to be testing for invalid signatures
are actually just testing that images aren't used if the entire TLV
block is missing.  Fix this by being more subtle about our corruptions.  If
there is no signature, corrupt that data being used to generate the
hash.  Otherwise, modify a bit at the end of the signature itself, which
should be detected by the signature checking code.

Signed-off-by: David Brown <david.brown@linaro.org>