### PR TITLE
sim: Fix ecdsa padding

### DIFF
--- a/sim/src/tlv.rs
+++ b/sim/src/tlv.rs
@@ -421,7 +421,6 @@ impl ManifestGen for TlvGen {
             let mut signature = signature.as_ref().to_vec();
             while signature.len() < 72 {
                 signature.push(0);
-                signature[1] += 1;
             }
 
             result.write_u16::<LittleEndian>(signature.len() as u16).unwrap();


### PR DESCRIPTION
For some reason, the ECDSA signature generation code attempted to
adjust the length of the ASN.1 of the actual signature.  It wasn't doing
this right, and was creating ASN.1 expecting many more entries than were
present.  The half-run parser in the tinycrypt ECDSA signature check
didn't care about this, but mbed TLS's signature check does care.

The intent of the padding was to be able to predict the size of the TLV
before writing it out.  Keep the padding for now, even though there is
no simple way of knowing how many pad bytes to remove (just removing
them will remove extra if there is a zero in the last byte of the
signature.

A future change will eliminate the padding, as it should no longer be
needed.

Signed-off-by: David Brown <david.brown@linaro.org>