### PR TITLE
Fix random upgrade failure using swap move 

### DIFF
--- a/boot/bootutil/src/bootutil_misc.c
+++ b/boot/bootutil/src/bootutil_misc.c
@@ -525,6 +525,9 @@ boot_write_enc_key(const struct flash_area *fap, uint8_t slot, const uint8_t *en
     int rc;
 
     off = boot_enc_key_off(fap, slot);
+    BOOT_LOG_DBG("writing enc_key; fa_id=%d off=0x%lx (0x%lx)",
+                 fap->fa_id, (unsigned long)off,
+                 (unsigned long)fap->fa_off + off);
     rc = flash_area_write(fap, off, enckey, BOOT_ENC_KEY_SIZE);
     if (rc != 0) {
         return BOOT_EFLASH;

--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -86,6 +86,7 @@ struct boot_status {
 #ifdef MCUBOOT_ENC_IMAGES
     uint8_t enckey[BOOT_NUM_SLOTS][BOOT_ENC_KEY_SIZE];
 #endif
+    int source;           /* Which slot contains swap status metadata */
 };
 
 #define BOOT_MAGIC_GOOD     1

--- a/boot/bootutil/src/swap_misc.c
+++ b/boot/bootutil/src/swap_misc.c
@@ -133,12 +133,11 @@ swap_read_status(struct boot_loader_state *state, struct boot_status *bs)
     const struct flash_area *fap;
     uint32_t off;
     uint8_t swap_info;
-    int status_loc;
     int area_id;
     int rc;
 
-    status_loc = swap_status_source(state);
-    switch (status_loc) {
+    bs->source = swap_status_source(state);
+    switch (bs->source) {
     case BOOT_STATUS_SOURCE_NONE:
         return 0;
 

--- a/boot/bootutil/src/swap_move.c
+++ b/boot/bootutil/src/swap_move.c
@@ -299,11 +299,13 @@ boot_move_sector_up(int idx, uint32_t sz, struct boot_loader_state *state,
     old_off = boot_img_sector_off(state, BOOT_PRIMARY_SLOT, idx - 1);
 
     if (bs->idx == BOOT_STATUS_IDX_0) {
-        rc = swap_erase_trailer_sectors(state, fap_pri);
-        assert(rc == 0);
+        if (bs->source != BOOT_STATUS_SOURCE_PRIMARY_SLOT) {
+            rc = swap_erase_trailer_sectors(state, fap_pri);
+            assert(rc == 0);
 
-        rc = swap_status_init(state, fap_pri, bs);
-        assert(rc == 0);
+            rc = swap_status_init(state, fap_pri, bs);
+            assert(rc == 0);
+        }
 
         rc = swap_erase_trailer_sectors(state, fap_sec);
         assert(rc == 0);


### PR DESCRIPTION
Fix an issue where an upgrade could fail to execute.

This happened randomly in the "perm_with_fails" test in the simulator; for it to happen the first reset had to occur just after writing the metadata to mark the start of a new upgrade, but before any swap happened; if followed by a new reset happening at a point where the metadata was erased and rewritten, it would result in an upgrade failure. The images would still be valid though although in their original slots.

The fix stores the detected boot status source in the state. When metadata was found in the primary slot we assume a swap has already started (even though no sector swap has happened) and avoid
erasing/rewriting it.
