### PR TITLE
Simulator logging improvements

### DIFF
--- a/boot/bootutil/include/bootutil/bootutil_log.h
+++ b/boot/bootutil/include/bootutil/bootutil_log.h
@@ -32,6 +32,7 @@ extern "C" {
 #define BOOT_LOG_WRN(...) MCUBOOT_LOG_WRN(__VA_ARGS__)
 #define BOOT_LOG_INF(...) MCUBOOT_LOG_INF(__VA_ARGS__)
 #define BOOT_LOG_DBG(...) MCUBOOT_LOG_DBG(__VA_ARGS__)
+#define BOOT_LOG_SIM(...) MCUBOOT_LOG_SIM(__VA_ARGS__)
 
 #else
 
@@ -39,6 +40,7 @@ extern "C" {
 #define BOOT_LOG_WRN(...) IGNORE(__VA_ARGS__)
 #define BOOT_LOG_INF(...) IGNORE(__VA_ARGS__)
 #define BOOT_LOG_DBG(...) IGNORE(__VA_ARGS__)
+#define BOOT_LOG_SIM(...) IGNORE(__VA_ARGS__)
 
 #endif /* MCUBOOT_HAVE_LOGGING */
 

--- a/boot/mynewt/mcuboot_config/include/mcuboot_config/mcuboot_logging.h
+++ b/boot/mynewt/mcuboot_config/include/mcuboot_config/mcuboot_logging.h
@@ -82,4 +82,6 @@
 #define MCUBOOT_LOG_DBG(...) IGNORE(__VA_ARGS__)
 #endif
 
+#define MCUBOOT_LOG_SIM(...) IGNORE(__VA_ARGS__)
+
 #endif

--- a/boot/zephyr/include/mcuboot_config/mcuboot_logging.h
+++ b/boot/zephyr/include/mcuboot_config/mcuboot_logging.h
@@ -21,6 +21,7 @@
 #define MCUBOOT_LOG_WRN(...) LOG_WRN(__VA_ARGS__)
 #define MCUBOOT_LOG_INF(...) LOG_INF(__VA_ARGS__)
 #define MCUBOOT_LOG_DBG(...) LOG_DBG(__VA_ARGS__)
+#define MCUBOOT_LOG_SIM(...) IGNORE(__VA_ARGS__)
 
 #include <logging/log.h>
 

--- a/sim/mcuboot-sys/csupport/mcuboot_config/mcuboot_logging.h
+++ b/sim/mcuboot-sys/csupport/mcuboot_config/mcuboot_logging.h
@@ -27,6 +27,7 @@
 #define MCUBOOT_LOG_LEVEL_WARNING  2
 #define MCUBOOT_LOG_LEVEL_INFO     3
 #define MCUBOOT_LOG_LEVEL_DEBUG    4
+#define MCUBOOT_LOG_LEVEL_SIM      5  /* RUST_LOG=trace */
 
 /*
  * The compiled log level determines the maximum level that can be
@@ -35,7 +36,7 @@
  * setting RUST_LOG to bootsim::api=info.
  */
 #ifndef MCUBOOT_LOG_LEVEL
-#define MCUBOOT_LOG_LEVEL MCUBOOT_LOG_LEVEL_INFO
+#define MCUBOOT_LOG_LEVEL MCUBOOT_LOG_LEVEL_DEBUG
 #endif
 
 #define MCUBOOT_LOG_MODULE_DECLARE(domain)	/* ignore */
@@ -48,6 +49,7 @@ int sim_log_enabled(int level);
     do {                                                                \
         if (sim_log_enabled(MCUBOOT_LOG_LEVEL_ERROR)) {                 \
             fprintf(stderr, "[ERR] " _fmt "\n", ##__VA_ARGS__);         \
+            fflush(stderr);                                             \
         }                                                               \
     } while (0)
 #else
@@ -59,6 +61,7 @@ int sim_log_enabled(int level);
     do {                                                                \
         if (sim_log_enabled(MCUBOOT_LOG_LEVEL_WARNING)) {               \
             fprintf(stderr, "[WRN] " _fmt "\n", ##__VA_ARGS__);         \
+            fflush(stderr);                                             \
         }                                                               \
     } while (0)
 #else
@@ -70,6 +73,7 @@ int sim_log_enabled(int level);
     do {                                                                \
         if (sim_log_enabled(MCUBOOT_LOG_LEVEL_INFO)) {                  \
             fprintf(stderr, "[INF] " _fmt "\n", ##__VA_ARGS__);         \
+            fflush(stderr);                                             \
         }                                                               \
     } while (0)
 #else
@@ -81,10 +85,23 @@ int sim_log_enabled(int level);
     do {                                                                \
         if (sim_log_enabled(MCUBOOT_LOG_LEVEL_DEBUG)) {                 \
             fprintf(stderr, "[DBG] " _fmt "\n", ##__VA_ARGS__);         \
+            fflush(stderr);                                             \
         }                                                               \
     } while (0)
 #else
 #define MCUBOOT_LOG_DBG(...) IGNORE(__VA_ARGS__)
+#endif
+
+#if MCUBOOT_LOG_LEVEL >= MCUBOOT_LOG_LEVEL_SIM
+#define MCUBOOT_LOG_SIM(_fmt, ...)                                      \
+    do {                                                                \
+        if (sim_log_enabled(MCUBOOT_LOG_LEVEL_SIM)) {                   \
+            fprintf(stderr, "[SIM] " _fmt "\n", ##__VA_ARGS__);         \
+            fflush(stderr);                                             \
+        }                                                               \
+    } while (0)
+#else
+#define MCUBOOT_LOG_SIM(...) IGNORE(__VA_ARGS__)
 #endif
 
 #endif /* __MCUBOOT_LOGGING_H__ */

--- a/sim/mcuboot-sys/csupport/run.c
+++ b/sim/mcuboot-sys/csupport/run.c
@@ -304,7 +304,7 @@ void flash_area_close(const struct flash_area *area)
 int flash_area_read(const struct flash_area *area, uint32_t off, void *dst,
                     uint32_t len)
 {
-    BOOT_LOG_DBG("%s: area=%d, off=%x, len=%x",
+    BOOT_LOG_SIM("%s: area=%d, off=%x, len=%x",
                  __func__, area->fa_id, off, len);
     return sim_flash_read(area->fa_device_id, area->fa_off + off, dst, len);
 }
@@ -312,7 +312,7 @@ int flash_area_read(const struct flash_area *area, uint32_t off, void *dst,
 int flash_area_write(const struct flash_area *area, uint32_t off, const void *src,
                      uint32_t len)
 {
-    BOOT_LOG_DBG("%s: area=%d, off=%x, len=%x", __func__,
+    BOOT_LOG_SIM("%s: area=%d, off=%x, len=%x", __func__,
                  area->fa_id, off, len);
     struct sim_context *ctx = sim_get_context();
     if (--(ctx->flash_counter) == 0) {
@@ -324,7 +324,7 @@ int flash_area_write(const struct flash_area *area, uint32_t off, const void *sr
 
 int flash_area_erase(const struct flash_area *area, uint32_t off, uint32_t len)
 {
-    BOOT_LOG_DBG("%s: area=%d, off=%x, len=%x", __func__,
+    BOOT_LOG_SIM("%s: area=%d, off=%x, len=%x", __func__,
                  area->fa_id, off, len);
     struct sim_context *ctx = sim_get_context();
     if (--(ctx->flash_counter) == 0) {
@@ -341,7 +341,7 @@ int flash_area_read_is_empty(const struct flash_area *area, uint32_t off,
     uint8_t *u8dst;
     int rc;
 
-    BOOT_LOG_DBG("%s: area=%d, off=%x, len=%x", __func__, area->fa_id, off, len);
+    BOOT_LOG_SIM("%s: area=%d, off=%x, len=%x", __func__, area->fa_id, off, len);
 
     rc = sim_flash_read(area->fa_device_id, area->fa_off + off, dst, len);
     if (rc) {

--- a/sim/mcuboot-sys/src/api.rs
+++ b/sim/mcuboot-sys/src/api.rs
@@ -209,7 +209,8 @@ pub extern fn sim_log_enabled(level: libc::c_int) -> libc::c_int {
         1 => log_enabled!(Level::Error),
         2 => log_enabled!(Level::Warn),
         3 => log_enabled!(Level::Info),
-        4 => log_enabled!(Level::Trace),
+        4 => log_enabled!(Level::Debug),
+        5 => log_enabled!(Level::Trace), // log level == SIM
         _ => false,
     };
     if res {


### PR DESCRIPTION
* Adds a new level (BOOT_LOG_SIM) to be used only for messages that are interesting while debugging bootutil in the simulator. This should be used for extra verbose prints.

* Also added fflushs after fprints to guarantee that messages are printed even when assertions are raised.

* For abstraction completeness, add "do nothing" definitions of _LOG_SIM to the other ports.

* Make DEBUG the default level when building the simulator (one can still lower verbosity using any other value for RUST_LOG).