### PR TITLE
boot: Clean up errors during sim test

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -538,8 +538,10 @@ boot_validate_slot(struct boot_loader_state *state, int slot,
              * continue booting from the primary slot.
              */
         }
+#if !defined(__BOOTSIM__)
         BOOT_LOG_ERR("Image in the %s slot is not valid!",
                      (slot == BOOT_PRIMARY_SLOT) ? "primary" : "secondary");
+#endif
         rc = -1;
         goto out;
     }

--- a/boot/bootutil/src/swap_move.c
+++ b/boot/bootutil/src/swap_move.c
@@ -162,7 +162,9 @@ swap_read_status_bytes(const struct flash_area *fap,
         /* This means there was an error writing status on the last
          * swap. Tell user and move on to validation!
          */
+#if !defined(__BOOTSIM__)
         BOOT_LOG_ERR("Detected inconsistent status!");
+#endif
 
 #if !defined(MCUBOOT_VALIDATE_PRIMARY_SLOT)
         /* With validation of the primary slot disabled, there is no way

--- a/boot/bootutil/src/swap_scratch.c
+++ b/boot/bootutil/src/swap_scratch.c
@@ -130,7 +130,9 @@ swap_read_status_bytes(const struct flash_area *fap,
         /* This means there was an error writing status on the last
          * swap. Tell user and move on to validation!
          */
+#if !defined(__BOOTSIM__)
         BOOT_LOG_ERR("Detected inconsistent status!");
+#endif
 
 #if !defined(MCUBOOT_VALIDATE_PRIMARY_SLOT)
         /* With validation of the primary slot disabled, there is no way


### PR DESCRIPTION
There are a few error messages printed by the boot code.  In a normal
platform, these are real errors, and really should print a message.
However, in the simulator, we intentionally create these scenarios, and
these errors only serve to distract from the rest of the test output.

Conditionalize the error prints based on whether we are running in the
simulator.

Signed-off-by: David Brown <david.brown@linaro.org>