### PR TITLE
imgtool: Add helpers for type in keygen command

### DIFF
--- a/scripts/imgtool/main.py
+++ b/scripts/imgtool/main.py
@@ -80,7 +80,8 @@ def get_password():
 @click.option('-p', '--password', is_flag=True,
               help='Prompt for password to protect key')
 @click.option('-t', '--type', metavar='type', required=True,
-              type=click.Choice(keygens.keys()))
+              type=click.Choice(keygens.keys()), prompt=True,
+              help='{}'.format('One of: {}'.format(', '.join(keygens.keys()))))
 @click.option('-k', '--key', metavar='filename', required=True)
 @click.command(help='Generate pub/private keypair')
 def keygen(type, key, password):


### PR DESCRIPTION
Apply a few improvements to the type parameter in the keygen command. Currently finding out the key types requires passing an invalid value to display what values are available. Instead add them the help page, so it shows an output like below:

```
  -t, --type type     One of: rsa-2048, rsa-3072, ecdsa-p256, ecdsa-p224,
                      ed25519  [required]
```

When no type is given in the CLI, ask for it:

```
$ ./imgtool.py keygen -k privkey.pem
Type (rsa-2048, rsa-3072, ecdsa-p256, ecdsa-p224, ed25519):
```