### PR TITLE
scripts: Add `imgtool.nix`

### DIFF
--- a/scripts/imgtool.nix
+++ b/scripts/imgtool.nix
@@ -1,0 +1,29 @@
+#
+# Nix environment for imgtool
+#
+# To install the environment
+#
+# $ nix-env --file imgtool.nix --install env-imgtool
+#
+# To load the environment
+#
+# $ load-env-imgtool
+#
+with import <nixpkgs> {};
+let
+  # Nixpkgs has fairly recent versions of the dependencies, so we can
+  # rely on them without having to build our own derivations.
+  imgtoolPythonEnv = python37.withPackages (
+    _: [
+      python37.pkgs.click
+      python37.pkgs.cryptography
+      python37.pkgs.intelhex
+      python37.pkgs.setuptools
+    ]
+  );
+in
+myEnvFun {
+  name = "imgtool";
+
+  buildInputs = [ imgtoolPythonEnv ];
+}


### PR DESCRIPTION
This allows us to create temporary, reproducible development environment using [Nix](https://nixos.org) for working with `imgtool.py`.