### PR TITLE
Add Tinycrypt based SHA-512 for ED25519

### DIFF
--- a/boot/bootutil/pkg.yml
+++ b/boot/bootutil/pkg.yml
@@ -49,5 +49,7 @@ pkg.deps.BOOTUTIL_USE_TINYCRYPT:
     - "@mcuboot/ext/mbedtls-asn1"
 
 pkg.deps.BOOTUTIL_SIGN_ED25519:
-    - "@apache-mynewt-core/crypto/mbedtls"
+    - "@mcuboot/ext/tinycrypt/lib"
+    - "@mcuboot/ext/tinycrypt-sha512/lib"
+    - "@mcuboot/ext/mbedtls-asn1"
     - "@mcuboot/ext/fiat"

--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -51,6 +51,8 @@ get_filename_component(MCUBOOT_DIR ${BOOT_DIR} DIRECTORY)
 # Path to tinycrypt library source subdirectory of MCUBOOT_DIR.
 set(TINYCRYPT_DIR "${MCUBOOT_DIR}/ext/tinycrypt/lib")
 assert_exists(TINYCRYPT_DIR)
+set(TINYCRYPT_SHA512_DIR "${MCUBOOT_DIR}/ext/tinycrypt-sha512/lib")
+assert_exists(TINYCRYPT_SHA512_DIR)
 # Path to crypto-fiat
 set(FIAT_DIR "${MCUBOOT_DIR}/ext/fiat")
 assert_exists(FIAT_DIR)
@@ -144,8 +146,27 @@ elseif(CONFIG_BOOT_SIGNATURE_TYPE_RSA)
   # is set using Kconfig.)
   zephyr_include_directories(include)
 elseif(CONFIG_BOOT_SIGNATURE_TYPE_ED25519)
-  # For ed25519, mbedTLS is used for ASN1 parsing and SHA512
-  zephyr_include_directories(include)
+  if(CONFIG_BOOT_USE_TINYCRYPT)
+    zephyr_library_include_directories(
+      ${MBEDTLS_ASN1_DIR}/include
+      ${BOOT_DIR}/zephyr/include
+      ${TINYCRYPT_DIR}/include
+      ${TINYCRYPT_SHA512_DIR}/include
+      )
+    zephyr_library_sources(
+      ${TINYCRYPT_DIR}/source/sha256.c
+      ${TINYCRYPT_DIR}/source/utils.c
+      ${TINYCRYPT_SHA512_DIR}/source/sha512.c
+      # Additionally pull in just the ASN.1 parser from mbedTLS.
+      ${MBEDTLS_ASN1_DIR}/src/asn1parse.c
+      ${MBEDTLS_ASN1_DIR}/src/platform_util.c
+      )
+    zephyr_library_compile_definitions(
+      MBEDTLS_CONFIG_FILE="${CMAKE_CURRENT_LIST_DIR}/include/mcuboot-mbedtls-cfg.h"
+      )
+  else()
+    zephyr_include_directories(include)
+  endif()
 
   zephyr_library_include_directories(
     ${BOOT_DIR}/zephyr/include

--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -76,16 +76,11 @@ endif
 config BOOT_SIGNATURE_TYPE_ECDSA_P256
 	bool "Elliptic curve digital signatures with curve P-256"
 
-config BOOT_SIGNATURE_TYPE_ED25519
-	bool "Edwards curve digital signatures using ed25519"
-	select BOOT_USE_MBEDTLS
-	select MBEDTLS
-
 if BOOT_SIGNATURE_TYPE_ECDSA_P256
 choice
 	prompt "Ecdsa implementation"
-	default BOOT_TINYCRYPT
-config BOOT_TINYCRYPT
+	default BOOT_ECDSA_TINYCRYPT
+config BOOT_ECDSA_TINYCRYPT
 	bool "Use tinycrypt"
 	select BOOT_USE_TINYCRYPT
 config BOOT_CC310
@@ -96,6 +91,24 @@ config BOOT_CC310
 	select BOOT_USE_CC310
 endchoice
 endif
+
+config BOOT_SIGNATURE_TYPE_ED25519
+	bool "Edwards curve digital signatures using ed25519"
+
+if BOOT_SIGNATURE_TYPE_ED25519
+choice
+	prompt "Ecdsa implementation"
+	default BOOT_ED25519_TINYCRYPT
+config BOOT_ED25519_TINYCRYPT
+	bool "Use tinycrypt"
+	select BOOT_USE_TINYCRYPT
+config BOOT_ED25519_MBEDTLS
+	bool "Use mbedTLS"
+	select BOOT_USE_MBEDTLS
+	select MBEDTLS
+endchoice
+endif
+
 endchoice
 
 config BOOT_SIGNATURE_KEY_FILE

--- a/ext/tinycrypt-sha512/lib/include/tinycrypt/sha512.h
+++ b/ext/tinycrypt-sha512/lib/include/tinycrypt/sha512.h
@@ -1,0 +1,129 @@
+/* sha512.h - TinyCrypt interface to a SHA-512 implementation */
+
+/*
+ *  Copyright (C) 2020 by Intel Corporation, All Rights Reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ *    - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ *    - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ *    - Neither the name of Intel Corporation nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ * @brief Interface to a SHA-512 implementation.
+ *
+ *  Overview:   SHA-512 is a NIST approved cryptographic hashing algorithm
+ *              specified in FIPS 180. A hash algorithm maps data of arbitrary
+ *              size to data of fixed length.
+ *
+ *  Security:   SHA-512 provides 256 bits of security against collision attacks
+ *              and 512 bits of security against pre-image attacks. SHA-512 does
+ *              NOT behave like a random oracle, but it can be used as one if
+ *              the string being hashed is prefix-free encoded before hashing.
+ *
+ *  Usage:      1) call tc_sha512_init to initialize a struct
+ *              tc_sha512_state_struct before hashing a new string.
+ *
+ *              2) call tc_sha512_update to hash the next string segment;
+ *              tc_sha512_update can be called as many times as needed to hash
+ *              all of the segments of a string; the order is important.
+ *
+ *              3) call tc_sha512_final to out put the digest from a hashing
+ *              operation.
+ */
+
+#ifndef __TC_SHA512_H__
+#define __TC_SHA512_H__
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define TC_SHA512_BLOCK_SIZE (128)
+#define TC_SHA512_DIGEST_SIZE (64)
+#define TC_SHA512_STATE_BLOCKS (TC_SHA512_DIGEST_SIZE/8)
+
+struct tc_sha512_state_struct {
+	uint64_t iv[TC_SHA512_STATE_BLOCKS];
+	uint64_t bits_hashed;
+	uint8_t leftover[TC_SHA512_BLOCK_SIZE];
+	size_t leftover_offset;
+};
+
+typedef struct tc_sha512_state_struct *TCSha512State_t;
+
+/**
+ *  @brief SHA512 initialization procedure
+ *  Initializes s
+ *  @return returns TC_CRYPTO_SUCCESS (1)
+ *          returns TC_CRYPTO_FAIL (0) if s == NULL
+ *  @param s Sha512 state struct
+ */
+int tc_sha512_init(TCSha512State_t s);
+
+/**
+ *  @brief SHA512 update procedure
+ *  Hashes data_length bytes addressed by data into state s
+ *  @return returns TC_CRYPTO_SUCCESS (1)
+ *          returns TC_CRYPTO_FAIL (0) if:
+ *                s == NULL,
+ *                s->iv == NULL,
+ *                data == NULL
+ *  @note Assumes s has been initialized by tc_sha512_init
+ *  @warning The state buffer 'leftover' is left in memory after processing
+ *           If your application intends to have sensitive data in this
+ *           buffer, remind to erase it after the data has been processed
+ *  @param s Sha512 state struct
+ *  @param data message to hash
+ *  @param datalen length of message to hash
+ */
+int tc_sha512_update (TCSha512State_t s, const uint8_t *data, size_t datalen);
+
+/**
+ *  @brief SHA512 final procedure
+ *  Inserts the completed hash computation into digest
+ *  @return returns TC_CRYPTO_SUCCESS (1)
+ *          returns TC_CRYPTO_FAIL (0) if:
+ *                s == NULL,
+ *                s->iv == NULL,
+ *                digest == NULL
+ *  @note Assumes: s has been initialized by tc_sha512_init
+ *        digest points to at least TC_SHA512_DIGEST_SIZE bytes
+ *  @warning The state buffer 'leftover' is left in memory after processing
+ *           If your application intends to have sensitive data in this
+ *           buffer, remind to erase it after the data has been processed
+ *  @param digest unsigned eight bit integer
+ *  @param Sha512 state struct
+ */
+int tc_sha512_final(uint8_t *digest, TCSha512State_t s);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __TC_SHA512_H__ */

--- a/ext/tinycrypt-sha512/lib/pkg.yml
+++ b/ext/tinycrypt-sha512/lib/pkg.yml
@@ -1,0 +1,30 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: ext/tinycrypt-sha512/lib
+pkg.description: "MCUboot's SHA512 for tinycrypt"
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+
+pkg.src_dirs:
+  - "source"
+
+pkg.cflags:
+    - "-std=c99"

--- a/ext/tinycrypt-sha512/lib/source/sha512.c
+++ b/ext/tinycrypt-sha512/lib/source/sha512.c
@@ -1,0 +1,234 @@
+/* sha512.c - TinyCrypt SHA-512 crypto hash algorithm implementation */
+
+/*
+ *  Copyright (C) 2020 by Intel Corporation, All Rights Reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ *    - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ *    - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ *    - Neither the name of Intel Corporation nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <tinycrypt/sha512.h>
+#include <tinycrypt/constants.h>
+#include <tinycrypt/utils.h>
+
+static void compress(uint64_t *iv, const uint8_t *data);
+
+int tc_sha512_init(TCSha512State_t s)
+{
+	/* input sanity check: */
+	if (s == (TCSha512State_t) 0) {
+		return TC_CRYPTO_FAIL;
+	}
+
+	/*
+	 * Setting the initial state values.
+	 * These values correspond to the first 64 bits of the fractional parts
+	 * of the square roots of the first 8 primes: 2, 3, 5, 7, 11, 13, 17
+	 * and 19.
+	 */
+	_set((uint8_t *) s, 0x00, sizeof(*s));
+	s->iv[0] = 0x6a09e667f3bcc908;
+	s->iv[1] = 0xbb67ae8584caa73b;
+	s->iv[2] = 0x3c6ef372fe94f82b;
+	s->iv[3] = 0xa54ff53a5f1d36f1;
+	s->iv[4] = 0x510e527fade682d1;
+	s->iv[5] = 0x9b05688c2b3e6c1f;
+	s->iv[6] = 0x1f83d9abfb41bd6b;
+	s->iv[7] = 0x5be0cd19137e2179;
+
+	return TC_CRYPTO_SUCCESS;
+}
+
+int tc_sha512_update(TCSha512State_t s, const uint8_t *data, size_t datalen)
+{
+	/* input sanity check: */
+	if (s == (TCSha512State_t) 0 || data == (void *) 0) {
+		return TC_CRYPTO_FAIL;
+	} else if (datalen == 0) {
+		return TC_CRYPTO_SUCCESS;
+	}
+
+	while (datalen-- > 0) {
+		s->leftover[s->leftover_offset++] = *(data++);
+		if (s->leftover_offset >= TC_SHA512_BLOCK_SIZE) {
+			compress(s->iv, s->leftover);
+			s->leftover_offset = 0;
+			s->bits_hashed += (TC_SHA512_BLOCK_SIZE << 3);
+		}
+	}
+
+	return TC_CRYPTO_SUCCESS;
+}
+
+int tc_sha512_final(uint8_t *digest, TCSha512State_t s)
+{
+	unsigned int i;
+
+	/* input sanity check: */
+	if (digest == (uint8_t *) 0 || s == (TCSha512State_t) 0) {
+		return TC_CRYPTO_FAIL;
+	}
+
+	s->bits_hashed += (s->leftover_offset << 3);
+
+	s->leftover[s->leftover_offset++] = 0x80; /* always room for one byte */
+	if (s->leftover_offset > (sizeof(s->leftover) - 16)) {
+		/* there is not room for all the padding in this block */
+		_set(s->leftover + s->leftover_offset, 0x00,
+		     sizeof(s->leftover) - s->leftover_offset);
+		compress(s->iv, s->leftover);
+		s->leftover_offset = 0;
+	}
+
+	/*
+	 * add the padding and the length in big-Endian format
+	 *
+	 * NOTE: SHA-512 uses 128 bits for the length of the message, but the
+	 * current implementation is only using 64 bits for size, leaving the
+	 * 64 "upper" bits zeroed.
+	 */
+	_set(s->leftover + s->leftover_offset, 0x00,
+	     sizeof(s->leftover) - 8 - s->leftover_offset);
+	s->leftover[sizeof(s->leftover) - 1]  = (uint8_t)(s->bits_hashed);
+	s->leftover[sizeof(s->leftover) - 2]  = (uint8_t)(s->bits_hashed >> 8);
+	s->leftover[sizeof(s->leftover) - 3]  = (uint8_t)(s->bits_hashed >> 16);
+	s->leftover[sizeof(s->leftover) - 4]  = (uint8_t)(s->bits_hashed >> 24);
+	s->leftover[sizeof(s->leftover) - 5]  = (uint8_t)(s->bits_hashed >> 32);
+	s->leftover[sizeof(s->leftover) - 6]  = (uint8_t)(s->bits_hashed >> 40);
+	s->leftover[sizeof(s->leftover) - 7]  = (uint8_t)(s->bits_hashed >> 48);
+	s->leftover[sizeof(s->leftover) - 8]  = (uint8_t)(s->bits_hashed >> 56);
+
+	/* hash the padding and length */
+	compress(s->iv, s->leftover);
+
+	/* copy the iv out to digest */
+	for (i = 0; i < TC_SHA512_STATE_BLOCKS; ++i) {
+		uint64_t t = *((uint64_t *) &s->iv[i]);
+		*digest++ = (uint8_t)(t >> 56);
+		*digest++ = (uint8_t)(t >> 48);
+		*digest++ = (uint8_t)(t >> 40);
+		*digest++ = (uint8_t)(t >> 32);
+		*digest++ = (uint8_t)(t >> 24);
+		*digest++ = (uint8_t)(t >> 16);
+		*digest++ = (uint8_t)(t >> 8);
+		*digest++ = (uint8_t)(t);
+	}
+
+	/* destroy the current state */
+	_set(s, 0, sizeof(*s));
+
+	return TC_CRYPTO_SUCCESS;
+}
+
+/*
+ * Initializing SHA-512 Hash constant words K.
+ * These values correspond to the first 64 bits of the fractional parts of the
+ * cube roots of the first 80 primes between 2 and 409.
+ */
+static const uint64_t k512[80] = {
+	0x428a2f98d728ae22, 0x7137449123ef65cd, 0xb5c0fbcfec4d3b2f, 0xe9b5dba58189dbbc, 0x3956c25bf348b538,
+	0x59f111f1b605d019, 0x923f82a4af194f9b, 0xab1c5ed5da6d8118, 0xd807aa98a3030242, 0x12835b0145706fbe,
+	0x243185be4ee4b28c, 0x550c7dc3d5ffb4e2, 0x72be5d74f27b896f, 0x80deb1fe3b1696b1, 0x9bdc06a725c71235,
+	0xc19bf174cf692694, 0xe49b69c19ef14ad2, 0xefbe4786384f25e3, 0x0fc19dc68b8cd5b5, 0x240ca1cc77ac9c65,
+	0x2de92c6f592b0275, 0x4a7484aa6ea6e483, 0x5cb0a9dcbd41fbd4, 0x76f988da831153b5, 0x983e5152ee66dfab,
+	0xa831c66d2db43210, 0xb00327c898fb213f, 0xbf597fc7beef0ee4, 0xc6e00bf33da88fc2, 0xd5a79147930aa725,
+	0x06ca6351e003826f, 0x142929670a0e6e70, 0x27b70a8546d22ffc, 0x2e1b21385c26c926, 0x4d2c6dfc5ac42aed,
+	0x53380d139d95b3df, 0x650a73548baf63de, 0x766a0abb3c77b2a8, 0x81c2c92e47edaee6, 0x92722c851482353b,
+	0xa2bfe8a14cf10364, 0xa81a664bbc423001, 0xc24b8b70d0f89791, 0xc76c51a30654be30, 0xd192e819d6ef5218,
+	0xd69906245565a910, 0xf40e35855771202a, 0x106aa07032bbd1b8, 0x19a4c116b8d2d0c8, 0x1e376c085141ab53,
+	0x2748774cdf8eeb99, 0x34b0bcb5e19b48a8, 0x391c0cb3c5c95a63, 0x4ed8aa4ae3418acb, 0x5b9cca4f7763e373,
+	0x682e6ff3d6b2b8a3, 0x748f82ee5defb2fc, 0x78a5636f43172f60, 0x84c87814a1f0ab72, 0x8cc702081a6439ec,
+	0x90befffa23631e28, 0xa4506cebde82bde9, 0xbef9a3f7b2c67915, 0xc67178f2e372532b, 0xca273eceea26619c,
+	0xd186b8c721c0c207, 0xeada7dd6cde0eb1e, 0xf57d4f7fee6ed178, 0x06f067aa72176fba, 0x0a637dc5a2c898a6,
+	0x113f9804bef90dae, 0x1b710b35131c471b, 0x28db77f523047d84, 0x32caab7b40c72493, 0x3c9ebe0a15c9bebc,
+	0x431d67c49c100d4c, 0x4cc5d4becb3e42b6, 0x597f299cfc657e2a, 0x5fcb6fab3ad6faec, 0x6c44198c4a475817
+};
+
+static inline uint64_t ROTR(uint64_t a, uint64_t n)
+{
+	return (((a) >> n) | ((a) << (64 - n)));
+}
+
+#define Sigma0(a)(ROTR((a), 28) ^ ROTR((a), 34) ^ ROTR((a), 39))
+#define Sigma1(a)(ROTR((a), 14) ^ ROTR((a), 18) ^ ROTR((a), 41))
+#define sigma0(a)(ROTR((a), 1) ^ ROTR((a), 8) ^ ((a) >> 7))
+#define sigma1(a)(ROTR((a), 19) ^ ROTR((a), 61) ^ ((a) >> 6))
+
+#define Ch(a, b, c)(((a) & (b)) ^ ((~(a)) & (c)))
+#define Maj(a, b, c)(((a) & (b)) ^ ((a) & (c)) ^ ((b) & (c)))
+
+static inline uint64_t BigEndian(const uint8_t **c)
+{
+	uint64_t n = 0;
+
+	n  = (uint64_t)(*((*c)++)) << 56;
+	n |= (uint64_t)(*((*c)++)) << 48;
+	n |= (uint64_t)(*((*c)++)) << 40;
+	n |= (uint64_t)(*((*c)++)) << 32;
+	n |= (uint64_t)(*((*c)++)) << 24;
+	n |= (uint64_t)(*((*c)++)) << 16;
+	n |= (uint64_t)(*((*c)++)) << 8;
+	n |= (uint64_t)(*((*c)++));
+	return n;
+}
+
+static void compress(uint64_t *iv, const uint8_t *data)
+{
+	uint64_t a, b, c, d, e, f, g, h;
+	uint64_t s0, s1;
+	uint64_t t1, t2;
+	uint64_t work_space[16];
+	uint64_t n;
+	unsigned int i;
+
+	a = iv[0]; b = iv[1]; c = iv[2]; d = iv[3];
+	e = iv[4]; f = iv[5]; g = iv[6]; h = iv[7];
+
+	for (i = 0; i < 16; ++i) {
+		n = BigEndian(&data);
+		t1 = work_space[i] = n;
+		t1 += h + Sigma1(e) + Ch(e, f, g) + k512[i];
+		t2 = Sigma0(a) + Maj(a, b, c);
+		h = g; g = f; f = e; e = d + t1;
+		d = c; c = b; b = a; a = t1 + t2;
+	}
+
+	for ( ; i < 80; ++i) {
+		s0 = work_space[(i+1)&0x0f];
+		s0 = sigma0(s0);
+		s1 = work_space[(i+14)&0x0f];
+		s1 = sigma1(s1);
+
+		t1 = work_space[i&0xf] += s0 + s1 + work_space[(i+9)&0xf];
+		t1 += h + Sigma1(e) + Ch(e, f, g) + k512[i];
+		t2 = Sigma0(a) + Maj(a, b, c);
+		h = g; g = f; f = e; e = d + t1;
+		d = c; c = b; b = a; a = t1 + t2;
+	}
+
+	iv[0] += a; iv[1] += b; iv[2] += c; iv[3] += d;
+	iv[4] += e; iv[5] += f; iv[6] += g; iv[7] += h;
+}

--- a/sim/mcuboot-sys/build.rs
+++ b/sim/mcuboot-sys/build.rs
@@ -97,16 +97,18 @@ fn main() {
         conf.file("../../ext/mbedtls-asn1/src/asn1parse.c");
     } else if sig_ed25519 {
         conf.define("MCUBOOT_SIGN_ED25519", None);
-        conf.define("MCUBOOT_USE_MBED_TLS", None);
+        conf.define("MCUBOOT_USE_TINYCRYPT", None);
 
-        conf.include("../../ext/mbedtls/include");
-        conf.file("../../ext/mbedtls/library/sha256.c");
-        conf.file("../../ext/mbedtls/library/sha512.c");
+        conf.include("../../ext/tinycrypt/lib/include");
+        conf.include("../../ext/tinycrypt-sha512/lib/include");
+        conf.include("../../ext/mbedtls-asn1/include");
+        conf.file("../../ext/tinycrypt/lib/source/sha256.c");
+        conf.file("../../ext/tinycrypt-sha512/lib/source/sha512.c");
+        conf.file("../../ext/tinycrypt/lib/source/utils.c");
         conf.file("csupport/keys.c");
         conf.file("../../ext/fiat/src/curve25519.c");
-        conf.file("../../ext/mbedtls/library/platform.c");
-        conf.file("../../ext/mbedtls/library/platform_util.c");
-        conf.file("../../ext/mbedtls/library/asn1parse.c");
+        conf.file("../../ext/mbedtls-asn1/src/platform_util.c");
+        conf.file("../../ext/mbedtls-asn1/src/asn1parse.c");
     } else if !enc_ec256 {
         // No signature type, only sha256 validation. The default
         // configuration file bundled with mbedTLS is sufficient.
@@ -221,7 +223,7 @@ fn main() {
     } else if (sig_ecdsa || enc_ec256) && !enc_kw {
         conf.define("MBEDTLS_CONFIG_FILE", Some("<config-asn1.h>"));
     } else if sig_ed25519 {
-        conf.define("MBEDTLS_CONFIG_FILE", Some("<config-ed25519.h>"));
+        conf.define("MBEDTLS_CONFIG_FILE", Some("<config-asn1.h>"));
     } else if enc_kw {
         conf.define("MBEDTLS_CONFIG_FILE", Some("<config-kw.h>"));
     }


### PR DESCRIPTION
Add option to build ed25519 with Tinycrypt.

This depends on https://github.com/intel/tinycrypt/pull/42 being accepted and update of local copy.

UPDATE: sha-512 was added separately while upstream PR is pending acceptance. 