### PR TITLE
add option for rollback protection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,8 @@ matrix:
       env: MULTI_FEATURES="sig-ecdsa enc-kw validate-primary-slot" TEST=sim
     - os: linux
       env: MULTI_FEATURES="sig-rsa validate-primary-slot overwrite-only large-write,sig-ecdsa enc-ec256 validate-primary-slot" TEST=sim
+    - os: linux
+      env: MULTI_FEATURES="sig-rsa validate-primary-slot overwrite-only downgrade-prevention" TEST=sim
 
     - os: linux
       language: go

--- a/boot/bootutil/include/bootutil/caps.h
+++ b/boot/bootutil/include/bootutil/caps.h
@@ -44,6 +44,7 @@ uint32_t bootutil_get_caps(void);
 #define BOOTUTIL_CAP_ED25519                (1<<9)
 #define BOOTUTIL_CAP_ENC_EC256              (1<<10)
 #define BOOTUTIL_CAP_SWAP_USING_MOVE        (1<<11)
+#define BOOTUTIL_CAP_DOWNGRADE_PREVENTION   (1<<12)
 
 /*
  * Query the number of images this bootloader is configured for.  This

--- a/boot/bootutil/src/caps.c
+++ b/boot/bootutil/src/caps.c
@@ -57,6 +57,9 @@ uint32_t bootutil_get_caps(void)
 #if defined(MCUBOOT_VALIDATE_PRIMARY_SLOT)
     res |= BOOTUTIL_CAP_VALIDATE_PRIMARY_SLOT;
 #endif
+#if defined(MCUBOOT_DOWNGRADE_PREVENTION)
+    res |= BOOTUTIL_CAP_DOWNGRADE_PREVENTION;
+#endif
 
     return res;
 }

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -510,6 +510,42 @@ boot_check_header_erased(struct boot_loader_state *state, int slot)
     return 0;
 }
 
+#if (BOOT_IMAGE_NUMBER > 1) || \
+    (defined(MCUBOOT_OVERWRITE_ONLY) && defined(MCUBOOT_DOWNGRADE_PREVENTION))
+/**
+ * Check if the version of the image is not older than required.
+ *
+ * @param req         Required minimal image version.
+ * @param ver         Version of the image to be checked.
+ *
+ * @return            0 if the version is sufficient, nonzero otherwise.
+ */
+static int
+boot_is_version_sufficient(struct image_version *req,
+                           struct image_version *ver)
+{
+    if (ver->iv_major > req->iv_major) {
+        return 0;
+    }
+    if (ver->iv_major < req->iv_major) {
+        return BOOT_EBADVERSION;
+    }
+    /* The major version numbers are equal. */
+    if (ver->iv_minor > req->iv_minor) {
+        return 0;
+    }
+    if (ver->iv_minor < req->iv_minor) {
+        return BOOT_EBADVERSION;
+    }
+    /* The minor version numbers are equal. */
+    if (ver->iv_revision < req->iv_revision) {
+        return BOOT_EBADVERSION;
+    }
+
+    return 0;
+}
+#endif
+
 /*
  * Check that there is a valid image in a slot
  *
@@ -541,6 +577,24 @@ boot_validate_slot(struct boot_loader_state *state, int slot,
         goto out;
     }
 
+#if defined(MCUBOOT_OVERWRITE_ONLY) && defined(MCUBOOT_DOWNGRADE_PREVENTION)
+    if (slot != BOOT_PRIMARY_SLOT) {
+        /* Check if version of secondary slot is sufficient */
+        rc = boot_is_version_sufficient(
+                &boot_img_hdr(state, BOOT_PRIMARY_SLOT)->ih_ver,
+                &boot_img_hdr(state, BOOT_SECONDARY_SLOT)->ih_ver);
+        if (rc != 0 && boot_check_header_erased(state, BOOT_PRIMARY_SLOT)) {
+            BOOT_LOG_ERR("insufficient version in secondary slot");
+            flash_area_erase(fap, 0, fap->fa_size);
+            /* Image in the secondary slot does not satisfy version requirement.
+             * Erase the image and continue booting from the primary slot.
+             */
+            rc = 1;
+            goto out;
+        }
+    }
+#endif
+
     if (!boot_is_header_valid(hdr, fap) || boot_image_check(state, hdr, fap, bs)) {
         if (slot != BOOT_PRIMARY_SLOT) {
             flash_area_erase(fap, 0, fap->fa_size);
@@ -552,7 +606,7 @@ boot_validate_slot(struct boot_loader_state *state, int slot,
         BOOT_LOG_ERR("Image in the %s slot is not valid!",
                      (slot == BOOT_PRIMARY_SLOT) ? "primary" : "secondary");
 #endif
-        rc = -1;
+        rc = 1;
         goto out;
     }
 
@@ -966,39 +1020,6 @@ boot_swap_image(struct boot_loader_state *state, struct boot_status *bs)
 #endif
 
 #if (BOOT_IMAGE_NUMBER > 1)
-/**
- * Check if the version of the image is not older than required.
- *
- * @param req         Required minimal image version.
- * @param ver         Version of the image to be checked.
- *
- * @return            0 if the version is sufficient, nonzero otherwise.
- */
-static int
-boot_is_version_sufficient(struct image_version *req,
-                           struct image_version *ver)
-{
-    if (ver->iv_major > req->iv_major) {
-        return 0;
-    }
-    if (ver->iv_major < req->iv_major) {
-        return BOOT_EBADVERSION;
-    }
-    /* The major version numbers are equal. */
-    if (ver->iv_minor > req->iv_minor) {
-        return 0;
-    }
-    if (ver->iv_minor < req->iv_minor) {
-        return BOOT_EBADVERSION;
-    }
-    /* The minor version numbers are equal. */
-    if (ver->iv_revision < req->iv_revision) {
-        return BOOT_EBADVERSION;
-    }
-
-    return 0;
-}
-
 /**
  * Check the image dependency whether it is satisfied and modify
  * the swap type if necessary.

--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -346,4 +346,14 @@ config UPDATEABLE_IMAGE_NUMBER
 	help
 	  Enables support of multi image update.
 
+config MCUBOOT_DOWNGRADE_PREVENTION
+	bool "Downgrade prevention"
+	depends on BOOT_UPGRADE_ONLY
+	help
+	  Prevent downgrades by enforcing incrementing version numbers.
+	  When this option is set, any upgrade must have greater major version
+	  or greater minor version with equal major version. This mechanism
+	  only protects against some attacks against version downgrades (for
+	  example, a JTAG could be used to write an older version).
+
 source "$ZEPHYR_BASE/Kconfig.zephyr"

--- a/boot/zephyr/include/mcuboot_config/mcuboot_config.h
+++ b/boot/zephyr/include/mcuboot_config/mcuboot_config.h
@@ -89,6 +89,10 @@
 #define MCUBOOT_IMAGE_NUMBER    1
 #endif
 
+#ifdef CONFIG_MCUBOOT_DOWNGRADE_PREVENTION
+#define MCUBOOT_DOWNGRADE_PREVENTION 1
+#endif
+
 /*
  * Enabling this option uses newer flash map APIs. This saves RAM and
  * avoids deprecated API usage.

--- a/docs/design.md
+++ b/docs/design.md
@@ -942,3 +942,11 @@ state after dependency check.
 
 For more information on adding dependency entries to an image,
 see: [imgtool](imgtool.md).
+
+## [Downgrade Prevention](#downgrade-prevention)
+
+Downgrade prevention is a feature which enforces that the new image must have a
+higher version number than the image it is replacing. This feature is enabled
+with the `MCUBOOT_DOWNGRADE_PREVENTION` option. Downgrade prevention is only
+available when the overwrite-based image update strategy is used
+(i.e. `MCUBOOT_OVERWRITE_ONLY` is set).

--- a/sim/Cargo.toml
+++ b/sim/Cargo.toml
@@ -20,6 +20,7 @@ enc-ec256 = ["mcuboot-sys/enc-ec256"]
 bootstrap = ["mcuboot-sys/bootstrap"]
 multiimage = ["mcuboot-sys/multiimage"]
 large-write = []
+downgrade-prevention = ["mcuboot-sys/downgrade-prevention"]
 
 [dependencies]
 byteorder = "1.3"

--- a/sim/mcuboot-sys/Cargo.toml
+++ b/sim/mcuboot-sys/Cargo.toml
@@ -47,6 +47,9 @@ bootstrap = []
 # Support multiple images (currently 2 instead of 1).
 multiimage = []
 
+# Check (in software) against version downgrades.
+downgrade-prevention = []
+
 [build-dependencies]
 cc = "1.0.25"
 

--- a/sim/mcuboot-sys/build.rs
+++ b/sim/mcuboot-sys/build.rs
@@ -22,6 +22,7 @@ fn main() {
     let enc_ec256 = env::var("CARGO_FEATURE_ENC_EC256").is_ok();
     let bootstrap = env::var("CARGO_FEATURE_BOOTSTRAP").is_ok();
     let multiimage = env::var("CARGO_FEATURE_MULTIIMAGE").is_ok();
+    let downgrade_prevention = env::var("CARGO_FEATURE_DOWNGRADE_PREVENTION").is_ok();
 
     let mut conf = cc::Build::new();
     conf.define("__BOOTSIM__", None);
@@ -31,12 +32,20 @@ fn main() {
     conf.define("MCUBOOT_MAX_IMG_SECTORS", Some("128"));
     conf.define("MCUBOOT_IMAGE_NUMBER", Some(if multiimage { "2" } else { "1" }));
 
+    if downgrade_prevention && !overwrite_only {
+        panic!("Downgrade prevention requires overwrite only");
+    }
+
     if bootstrap {
         conf.define("MCUBOOT_BOOTSTRAP", None);
     }
 
     if validate_primary_slot {
         conf.define("MCUBOOT_VALIDATE_PRIMARY_SLOT", None);
+    }
+
+    if downgrade_prevention {
+        conf.define("MCUBOOT_DOWNGRADE_PREVENTION", None);
     }
 
     // Currently no more than one sig type can be used simultaneously.

--- a/sim/src/caps.rs
+++ b/sim/src/caps.rs
@@ -16,6 +16,7 @@ pub enum Caps {
     Ed25519              = (1 << 9),
     EncEc256             = (1 << 10),
     SwapUsingMove        = (1 << 11),
+    DowngradePrevention  = (1 << 12),
 }
 
 impl Caps {

--- a/sim/src/image.rs
+++ b/sim/src/image.rs
@@ -39,6 +39,7 @@ use crate::depends::{
     Depender,
     DepTest,
     DepType,
+    NO_DEPS,
     PairDep,
     UpgradeInfo,
 };
@@ -171,7 +172,7 @@ impl ImagesBuilder {
             let dep: Box<dyn Depender> = if num_images > 1 {
                 Box::new(PairDep::new(num_images, image_num, deps))
             } else {
-                Box::new(BoringDep(image_num))
+                Box::new(BoringDep::new(image_num, deps))
             };
             let primaries = install_image(&mut flash, &slots[0], 42784, &*dep, false);
             let upgrades = match deps.depends[image_num] {
@@ -216,7 +217,7 @@ impl ImagesBuilder {
     pub fn make_bad_secondary_slot_image(self) -> Images {
         let mut bad_flash = self.flash;
         let images = self.slots.into_iter().enumerate().map(|(image_num, slots)| {
-            let dep = BoringDep(image_num);
+            let dep = BoringDep::new(image_num, &NO_DEPS);
             let primaries = install_image(&mut bad_flash, &slots[0], 32784, &dep, false);
             let upgrades = install_image(&mut bad_flash, &slots[1], 41928, &dep, true);
             OneImage {
@@ -558,6 +559,37 @@ impl Images {
 
         if fails > 0 {
             error!("Error running upgrade without revert");
+        }
+
+        fails > 0
+    }
+
+    // Test that an upgrade is rejected.  Assumes that the image was build
+    // such that the upgrade is instead a downgrade.
+    pub fn run_nodowngrade(&self) -> bool {
+        if !Caps::DowngradePrevention.present() {
+            return false;
+        }
+
+        let mut flash = self.flash.clone();
+        let mut fails = 0;
+
+        info!("Try no downgrade");
+
+        // First, do a normal upgrade.
+        let (result, _) = c::boot_go(&mut flash, &self.areadesc, None, false);
+        if result != 0 {
+            warn!("Failed first boot");
+            fails += 1;
+        }
+
+        if !self.verify_images(&flash, 0, 0) {
+            warn!("Failed verification after downgrade rejection");
+            fails += 1;
+        }
+
+        if fails > 0 {
+            error!("Error testing downgrade rejection");
         }
 
         fails > 0
@@ -1441,6 +1473,7 @@ fn install_ptable(flash: &mut SimMultiFlash, areadesc: &AreaDesc) {
 
 /// The image header
 #[repr(C)]
+#[derive(Debug)]
 pub struct ImageHeader {
     magic: u32,
     load_addr: u32,

--- a/sim/src/lib.rs
+++ b/sim/src/lib.rs
@@ -17,7 +17,9 @@ pub use crate::{
         DepTest,
         DepType,
         UpgradeInfo,
-        NO_DEPS,},
+        NO_DEPS,
+        REV_DEPS,
+    },
     image::{
         ImagesBuilder,
         Images,

--- a/sim/tests/core.rs
+++ b/sim/tests/core.rs
@@ -7,6 +7,7 @@ use bootsim::{
     ImagesBuilder,
     Images,
     NO_DEPS,
+    REV_DEPS,
     testlog,
 };
 use std::{
@@ -49,6 +50,7 @@ sim_test!(perm_with_random_fails, make_image(&NO_DEPS, true), run_perm_with_rand
 sim_test!(norevert, make_image(&NO_DEPS, true), run_norevert());
 sim_test!(status_write_fails_complete, make_image(&NO_DEPS, true), run_with_status_fails_complete());
 sim_test!(status_write_fails_with_reset, make_image(&NO_DEPS, true), run_with_status_fails_with_reset());
+sim_test!(downgrade_prevention, make_image(&REV_DEPS, true), run_nodowngrade());
 
 // Test various combinations of incorrect dependencies.
 test_shell!(dependency_combos, r, {
@@ -70,18 +72,21 @@ pub static TEST_DEPS: &[DepTest] = &[
     DepTest {
         depends: [DepType::Nothing, DepType::Nothing],
         upgrades: [UpgradeInfo::Upgraded, UpgradeInfo::Upgraded],
+        downgrade: false,
     },
 
     // If all of the dependencies are met, we should also upgrade.
     DepTest {
         depends: [DepType::Correct, DepType::Correct],
         upgrades: [UpgradeInfo::Upgraded, UpgradeInfo::Upgraded],
+        downgrade: false,
     },
 
     // If none of the dependencies are met, the images should be held.
     DepTest {
         depends: [DepType::Newer, DepType::Newer],
         upgrades: [UpgradeInfo::Held, UpgradeInfo::Held],
+        downgrade: false,
     },
 
     // If the first image is not met, we should hold back on the
@@ -90,12 +95,14 @@ pub static TEST_DEPS: &[DepTest] = &[
     DepTest {
         depends: [DepType::Newer, DepType::Correct],
         upgrades: [UpgradeInfo::Held, UpgradeInfo::Held],
+        downgrade: false,
     },
 
     // Test the variant in the other direction.
     DepTest {
         depends: [DepType::Correct, DepType::Newer],
         upgrades: [UpgradeInfo::Held, UpgradeInfo::Held],
+        downgrade: false,
     },
 
     // Test where only the first image is upgraded, and there are no
@@ -103,18 +110,21 @@ pub static TEST_DEPS: &[DepTest] = &[
     DepTest {
         depends: [DepType::Nothing, DepType::NoUpgrade],
         upgrades: [UpgradeInfo::Upgraded, UpgradeInfo::Held],
+        downgrade: false,
     },
 
     // Test one image with a valid dependency on the first image.
     DepTest {
         depends: [DepType::OldCorrect, DepType::NoUpgrade],
         upgrades: [UpgradeInfo::Upgraded, UpgradeInfo::Held],
+        downgrade: false,
     },
 
     // Test one image with an invalid dependency on the first image.
     DepTest {
         depends: [DepType::Newer, DepType::NoUpgrade],
         upgrades: [UpgradeInfo::Held, UpgradeInfo::Held],
+        downgrade: false,
     },
 
     // Test where only the second image is upgraded, and there are no
@@ -122,18 +132,21 @@ pub static TEST_DEPS: &[DepTest] = &[
     DepTest {
         depends: [DepType::NoUpgrade, DepType::Nothing],
         upgrades: [UpgradeInfo::Held, UpgradeInfo::Upgraded],
+        downgrade: false,
     },
 
     // Test one image with a valid dependency on the second image.
     DepTest {
         depends: [DepType::NoUpgrade, DepType::OldCorrect],
         upgrades: [UpgradeInfo::Held, UpgradeInfo::Upgraded],
+        downgrade: false,
     },
 
     // Test one image with an invalid dependency on the second image.
     DepTest {
         depends: [DepType::NoUpgrade, DepType::Newer],
         upgrades: [UpgradeInfo::Held, UpgradeInfo::Held],
+        downgrade: false,
     },
 ];
 


### PR DESCRIPTION
Depends on 'MCUBOOT_OVERWRITE_ONLY' option since swap info is not protected
by signature

Proposal to issue #224 

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>