### PR TITLE
Extra swap without scratch check; better sim coverage; remove Zephyr [EXPERIMENTAL] option

### DIFF
--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -280,6 +280,7 @@ int boot_copy_region(struct boot_loader_state *state,
                      const struct flash_area *fap_dst,
                      uint32_t off_src, uint32_t off_dst, uint32_t sz);
 int boot_erase_region(const struct flash_area *fap, uint32_t off, uint32_t sz);
+bool boot_status_is_reset(const struct boot_status *bs);
 
 #ifdef MCUBOOT_ENC_IMAGES
 int boot_write_enc_key(const struct flash_area *fap, uint8_t slot,

--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -127,7 +127,7 @@ config BOOT_UPGRADE_ONLY
 	  uses a much simpler code path.
 
 config BOOT_SWAP_USING_MOVE
-	bool "Swap mode that can run without a scratch partition [EXPERIMENTAL]"
+	bool "Swap mode that can run without a scratch partition"
 	default n
 	help
 	  If y, the swap upgrade is done in two steps, where first every

--- a/sim/mcuboot-sys/build.rs
+++ b/sim/mcuboot-sys/build.rs
@@ -178,6 +178,7 @@ fn main() {
         conf.define("MCUBOOT_ENCRYPT_EC256", None);
         conf.define("MCUBOOT_ENC_IMAGES", None);
         conf.define("MCUBOOT_USE_TINYCRYPT", None);
+        conf.define("MCUBOOT_SWAP_SAVE_ENCTLV", None);
 
         conf.file("../../boot/bootutil/src/encrypted.c");
         conf.file("csupport/keys.c");


### PR DESCRIPTION
*From commit messages*:

* boot: Add free space check for swap without scratch

Add a missing test which ensures that there is enough free sectors to perform an upgrade when using the move strategy; this basically checks that the sectors used by the trailer don't overlap the last sector required for a move up operation.

* sim: enable saving encrypted TLV for ECIES

This changes the simulator to save the encryption TLV itself instead of the unecrypted AES-128 key when doing the ECIES encryption test, to add proper test coverage of this configuration option.

* boot: zephyr: remove [EXPERIMENTAL] from config option

Swap without scratch has been tested enough and no obvious bugs (or "show stopper) bugs seem to exist; so remove [EXPERIMENTAL] and make it "stable".