### PR TITLE
sim: Add explicit copyright and licenses to the sim

### DIFF
--- a/sim/mcuboot-sys/src/api.rs
+++ b/sim/mcuboot-sys/src/api.rs
@@ -1,3 +1,8 @@
+// Copyright (c) 2017-2019 Linaro LTD
+// Copyright (c) 2018-2019 JUUL Labs
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! HAL api for MyNewt applications
 
 use crate::area::CAreaDesc;

--- a/sim/mcuboot-sys/src/area.rs
+++ b/sim/mcuboot-sys/src/area.rs
@@ -1,3 +1,9 @@
+// Copyright (c) 2017-2019 Linaro LTD
+// Copyright (c) 2018-2019 JUUL Labs
+// Copyright (c) 2019 Arm Limited
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Describe flash areas.
 
 use simflash::{Flash, SimFlash, Sector};

--- a/sim/mcuboot-sys/src/c.rs
+++ b/sim/mcuboot-sys/src/c.rs
@@ -1,4 +1,10 @@
-/// Interface wrappers to C API entering to the bootloader
+// Copyright (c) 2017-2019 Linaro LTD
+// Copyright (c) 2017-2019 JUUL Labs
+// Copyright (c) 2019 Arm Limited
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Interface wrappers to C API entering to the bootloader
 
 use crate::area::AreaDesc;
 use simflash::SimMultiFlash;

--- a/sim/mcuboot-sys/src/lib.rs
+++ b/sim/mcuboot-sys/src/lib.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2017-2019 Linaro LTD
+//
+// SPDX-License-Identifier: Apache-2.0
+
 mod area;
 pub mod c;
 

--- a/sim/simflash/src/lib.rs
+++ b/sim/simflash/src/lib.rs
@@ -1,3 +1,8 @@
+// Copyright (c) 2017-2019 Linaro LTD
+// Copyright (c) 2017-2018 JUUL Labs
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! A flash simulator
 //!
 //! This module is capable of simulating the type of NOR flash commonly used in microcontrollers.

--- a/sim/simflash/src/pdump.rs
+++ b/sim/simflash/src/pdump.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2017 Linaro LTD
+//
+// SPDX-License-Identifier: Apache-2.0
+
 // Printable hexdump.
 
 pub trait HexDump {

--- a/sim/src/caps.rs
+++ b/sim/src/caps.rs
@@ -1,3 +1,9 @@
+// Copyright (c) 2017-2019 Linaro LTD
+// Copyright (c) 2019 JUUL Labs
+// Copyright (c) 2019 Arm Limited
+//
+// SPDX-License-Identifier: Apache-2.0
+
 // Query the bootloader's capabilities.
 
 #[repr(u32)]

--- a/sim/src/depends.rs
+++ b/sim/src/depends.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2019 Linaro LTD
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Support and tests related to the dependency management for multi-image
 //! support.
 

--- a/sim/src/image.rs
+++ b/sim/src/image.rs
@@ -1,3 +1,9 @@
+// Copyright (c) 2019 Linaro LTD
+// Copyright (c) 2019-2020 JUUL Labs
+// Copyright (c) 2019 Arm Limited
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use byteorder::{
     LittleEndian, WriteBytesExt,
 };

--- a/sim/src/lib.rs
+++ b/sim/src/lib.rs
@@ -1,3 +1,9 @@
+// Copyright (c) 2017-2019 Linaro LTD
+// Copyright (c) 2017-2019 JUUL Labs
+// Copyright (c) 2019 Arm Limited
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use docopt::Docopt;
 use log::{warn, error};
 use std::{

--- a/sim/src/main.rs
+++ b/sim/src/main.rs
@@ -1,3 +1,8 @@
+// Copyright (c) 2017-2019 Linaro LTD
+// Copyright (c) 2017-2019 JUUL Labs
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use env_logger;
 
 use bootsim;

--- a/sim/src/testlog.rs
+++ b/sim/src/testlog.rs
@@ -1,3 +1,8 @@
+// Copyright (c) 2017 Linaro LTD
+// Copyright (c) 2019 JUUL Labs
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Logging support for the test framework.
 //!
 //! https://stackoverflow.com/questions/30177845/how-to-initialize-the-logger-for-integration-tests

--- a/sim/src/tlv.rs
+++ b/sim/src/tlv.rs
@@ -1,3 +1,8 @@
+// Copyright (c) 2017-2020 Linaro LTD
+// Copyright (c) 2017-2020 JUUL Labs
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! TLV Support
 //!
 //! mcuboot images are followed immediately by a list of TLV items that contain integrity

--- a/sim/tests/core.rs
+++ b/sim/tests/core.rs
@@ -1,3 +1,8 @@
+// Copyright (c) 2017-2019 Linaro LTD
+// Copyright (c) 2017-2019 JUUL Labs
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Core tests
 //!
 //! Run the existing testsuite as a Rust unit test.


### PR DESCRIPTION
Add an apache SPDX header and explicit license lines.  The date ranges
of the license lines is derived from the git history.  Having these
explicitly present will make contributions from other parties easier, as
they will simply be able to add their own copyright line, rather than
having to describe that it only covers modifications.

Signed-off-by: David Brown <david.brown@linaro.org>