### PR TITLE
cmake: use zephyr base in relative path

### DIFF
--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -60,7 +60,7 @@ assert_exists(MBEDTLS_ASN1_DIR)
 set(NRF_DIR "${MCUBOOT_DIR}/ext/nrf")
 
 if(CONFIG_BOOT_USE_NRF_CC310_BL)
-set(NRFXLIB_DIR ${MCUBOOT_DIR}/../nrfxlib)
+set(NRFXLIB_DIR $ENV{ZEPHYR_BASE}/../nrfxlib)
 assert_exists(NRFXLIB_DIR)
 # Don't include this if we are using west
  add_subdirectory(${NRFXLIB_DIR} ${PROJECT_BINARY_DIR}/nrfxlib)


### PR DESCRIPTION
To be more robust in the placement of MCUBoot directory,
use the ZEPHYR_BASE env variable to locate
nrfxlib directory.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>