### PR TITLE
introduce HW rollback protection

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -8,4 +8,4 @@ Portions of this software were developed at
 Runtime Inc, copyright 2015.
 
 Portions of this software were developed at
-Arm Limited, copyright 2019.
+Arm Limited, copyright 2019-2020.

--- a/boot/bootutil/include/bootutil/image.h
+++ b/boot/bootutil/include/bootutil/image.h
@@ -18,7 +18,7 @@
  */
 
 /*
- * Modifications are Copyright (c) 2019 Arm Limited.
+ * Modifications are Copyright (c) 2019-2020 Arm Limited.
  */
 
 #ifndef H_IMAGE_
@@ -84,6 +84,7 @@ struct flash_area;
 #define IMAGE_TLV_ENC_KW128         0x31   /* Key encrypted with AES-KW-128 */
 #define IMAGE_TLV_ENC_EC256         0x32   /* Key encrypted with ECIES-EC256 */
 #define IMAGE_TLV_DEPENDENCY        0x40   /* Image depends on other image */
+#define IMAGE_TLV_SEC_CNT           0x50   /* security counter */
 #define IMAGE_TLV_ANY               0xffff /* Used to iterate over all TLV */
 
 struct image_version {
@@ -162,6 +163,10 @@ int bootutil_tlv_iter_begin(struct image_tlv_iter *it,
                             bool prot);
 int bootutil_tlv_iter_next(struct image_tlv_iter *it, uint32_t *off,
                            uint16_t *len, uint16_t *type);
+
+int32_t bootutil_get_img_security_cnt(struct image_header *hdr,
+                                      const struct flash_area *fap,
+                                      uint32_t *security_cnt);
 
 #ifdef __cplusplus
 }

--- a/boot/bootutil/include/bootutil/security_cnt.h
+++ b/boot/bootutil/include/bootutil/security_cnt.h
@@ -1,0 +1,69 @@
+/*
+ *  Copyright (c) 2019-2020, Arm Limited. All rights reserved.
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef __SECURITY_CNT_H__
+#define __SECURITY_CNT_H__
+
+/**
+ * @file security_cnt.h
+ *
+ * @note The interface must be implemented in a fail-safe way that is
+ *       resistant to asynchronous power failures or it can use hardware
+ *       counters that have this capability, if supported by the platform.
+ *       When a counter incrementation was interrupted it must be able to
+ *       continue the incrementation process or recover the previous consistent
+ *       status of the counters. If the counters have reached a stable status
+ *       (every counter incrementation operation has finished), from that point
+ *       their value cannot decrease due to any kind of power failure.
+ *
+ * @note A security counter might be implemented using non-volatile OTP memory
+ *       (i.e. fuses) in which case it is the responsibility of the platform
+ *       code to map each possible security counter values onto the fuse bits
+ *       as the direct usage of counter values can be costly / impractical.
+ */
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Initialises the security counters.
+ *
+ * @return                  0 on success; nonzero on failure.
+ */
+int32_t boot_nv_security_counter_init(void);
+
+/**
+ * Reads the stored value of a given image's security counter.
+ *
+ * @param image_id          Index of the image (from 0).
+ * @param security_cnt      Pointer to store the security counter value.
+ *
+ * @return                  0 on success; nonzero on failure.
+ */
+int32_t boot_nv_security_counter_get(uint32_t image_id, uint32_t *security_cnt);
+
+/**
+ * Updates the stored value of a given image's security counter with a new
+ * security counter value if the new one is greater.
+ *
+ * @param image_id          Index of the image (from 0).
+ * @param img_security_cnt  New security counter value. The new value must be
+ *                          between 0 and UINT32_MAX and it must be greater than
+ *                          or equal to the current security counter value.
+ *
+ * @return                  0 on success; nonzero on failure.
+ */
+int32_t boot_nv_security_counter_update(uint32_t image_id,
+                                        uint32_t img_security_cnt);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __SECURITY_CNT_H__ */

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -18,7 +18,7 @@
  */
 
 /*
- * Modifications are Copyright (c) 2019 Arm Limited.
+ * Modifications are Copyright (c) 2019-2020 Arm Limited.
  */
 
 /**
@@ -38,6 +38,7 @@
 #include "bootutil_priv.h"
 #include "swap_priv.h"
 #include "bootutil/bootutil_log.h"
+#include "bootutil/security_cnt.h"
 
 #ifdef MCUBOOT_ENC_IMAGES
 #include "bootutil/enc_key.h"
@@ -374,7 +375,7 @@ done:
 }
 
 /*
- * Validate image hash/signature in a slot.
+ * Validate image hash/signature and optionally the security counter in a slot.
  */
 static int
 boot_image_check(struct boot_loader_state *state, struct image_header *hdr,
@@ -649,6 +650,51 @@ boot_validated_swap_type(struct boot_loader_state *state,
     return swap_type;
 }
 
+#ifdef MCUBOOT_HW_ROLLBACK_PROT
+/**
+ * Updates the stored security counter value with the image's security counter
+ * value which resides in the given slot, only if it's greater than the stored
+ * value.
+ *
+ * @param image_index   Index of the image to determine which security
+ *                      counter to update.
+ * @param slot          Slot number of the image.
+ * @param hdr           Pointer to the image header structure of the image
+ *                      that is currently stored in the given slot.
+ *
+ * @return              0 on success; nonzero on failure.
+ */
+static int
+boot_update_security_counter(uint8_t image_index, int slot,
+                             struct image_header *hdr)
+{
+    const struct flash_area *fap = NULL;
+    uint32_t img_security_cnt;
+    int rc;
+
+    rc = flash_area_open(flash_area_id_from_multi_image_slot(image_index, slot),
+                         &fap);
+    if (rc != 0) {
+        rc = BOOT_EFLASH;
+        goto done;
+    }
+
+    rc = bootutil_get_img_security_cnt(hdr, fap, &img_security_cnt);
+    if (rc != 0) {
+        goto done;
+    }
+
+    rc = boot_nv_security_counter_update(image_index, img_security_cnt);
+    if (rc != 0) {
+        goto done;
+    }
+
+done:
+    flash_area_close(fap);
+    return rc;
+}
+#endif /* MCUBOOT_HW_ROLLBACK_PROT */
+
 /**
  * Erases a region of flash.
  *
@@ -859,6 +905,20 @@ boot_copy_image(struct boot_loader_state *state, struct boot_status *bs)
     BOOT_LOG_INF("Copying the secondary slot to the primary slot: 0x%zx bytes",
                  size);
     rc = boot_copy_region(state, fap_secondary_slot, fap_primary_slot, 0, 0, size);
+
+#ifdef MCUBOOT_HW_ROLLBACK_PROT
+    /* Update the stored security counter with the new image's security counter
+     * value. Both slots hold the new image at this point, but the secondary
+     * slot's image header must be passed since the image headers in the
+     * boot_data structure have not been updated yet.
+     */
+    rc = boot_update_security_counter(BOOT_CURR_IMG(state), BOOT_PRIMARY_SLOT,
+                                boot_img_hdr(state, BOOT_SECONDARY_SLOT));
+    if (rc != 0) {
+        BOOT_LOG_ERR("Security counter update failed after image upgrade.");
+        return rc;
+    }
+#endif /* MCUBOOT_HW_ROLLBACK_PROT */
 
     /*
      * Erases header and trailer. The trailer is erased because when a new
@@ -1225,6 +1285,29 @@ boot_perform_update(struct boot_loader_state *state, struct boot_status *bs)
             BOOT_SWAP_TYPE(state) = swap_type = BOOT_SWAP_TYPE_PANIC;
         }
     }
+
+#ifdef MCUBOOT_HW_ROLLBACK_PROT
+    if (swap_type == BOOT_SWAP_TYPE_PERM) {
+        /* Update the stored security counter with the new image's security
+         * counter value. The primary slot holds the new image at this point,
+         * but the secondary slot's image header must be passed since image
+         * headers in the boot_data structure have not been updated yet.
+         *
+         * In case of a permanent image swap mcuboot will never attempt to
+         * revert the images on the next reboot. Therefore, the security
+         * counter must be increased right after the image upgrade.
+         */
+        rc = boot_update_security_counter(
+                                    BOOT_CURR_IMG(state),
+                                    BOOT_PRIMARY_SLOT,
+                                    boot_img_hdr(state, BOOT_SECONDARY_SLOT));
+        if (rc != 0) {
+            BOOT_LOG_ERR("Security counter update failed after "
+                         "image upgrade.");
+            BOOT_SWAP_TYPE(state) = BOOT_SWAP_TYPE_PANIC;
+        }
+    }
+#endif /* MCUBOOT_HW_ROLLBACK_PROT */
 
     if (BOOT_IS_UPGRADE(swap_type)) {
         rc = swap_set_copy_done(BOOT_CURR_IMG(state));
@@ -1680,7 +1763,31 @@ context_boot_go(struct boot_loader_state *state, struct boot_rsp *rsp)
             rc = BOOT_EBADIMAGE;
             goto out;
         }
-#endif
+#endif /* MCUBOOT_VALIDATE_PRIMARY_SLOT */
+
+#ifdef MCUBOOT_HW_ROLLBACK_PROT
+        /* Update the stored security counter with the active image's security
+         * counter value. It will only be updated if the new security counter is
+         * greater than the stored value.
+         *
+         * In case of a successful image swapping when the swap type is TEST the
+         * security counter can be increased only after a reset, when the swap
+         * type is NONE and the image has marked itself "OK" (the image_ok flag
+         * has been set). This way a "revert" can be performed when it's
+         * necessary.
+         */
+        if (BOOT_SWAP_TYPE(state) == BOOT_SWAP_TYPE_NONE) {
+            rc = boot_update_security_counter(
+                                    BOOT_CURR_IMG(state),
+                                    BOOT_PRIMARY_SLOT,
+                                    boot_img_hdr(state, BOOT_PRIMARY_SLOT));
+            if (rc != 0) {
+                BOOT_LOG_ERR("Security counter update failed after image "
+                             "validation.");
+                goto out;
+            }
+        }
+#endif /* MCUBOOT_HW_ROLLBACK_PROT */
     }
 
 #if (BOOT_IMAGE_NUMBER > 1)

--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -1,4 +1,5 @@
 # Copyright (c) 2017 Linaro Limited
+# Copyright (c) 2020 Arm Limited
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -361,8 +362,12 @@ config UPDATEABLE_IMAGE_NUMBER
 	help
 	  Enables support of multi image update.
 
+choice
+	prompt "Downgrade prevention"
+	optional
+
 config MCUBOOT_DOWNGRADE_PREVENTION
-	bool "Downgrade prevention"
+	bool "SW based downgrade prevention"
 	depends on BOOT_UPGRADE_ONLY
 	help
 	  Prevent downgrades by enforcing incrementing version numbers.
@@ -370,5 +375,15 @@ config MCUBOOT_DOWNGRADE_PREVENTION
 	  or greater minor version with equal major version. This mechanism
 	  only protects against some attacks against version downgrades (for
 	  example, a JTAG could be used to write an older version).
+
+config MCUBOOT_HW_DOWNGRADE_PREVENTION
+	bool "HW based downgrade prevention"
+	help
+	  Prevent undesirable/malicious software downgrades. When this option is
+	  set, any upgrade must have greater or equal security counter value.
+	  Because of the acceptance of equal values it allows for software
+	  downgrade to some extent.
+
+endchoice
 
 source "Kconfig.zephyr"

--- a/boot/zephyr/include/mcuboot_config/mcuboot_config.h
+++ b/boot/zephyr/include/mcuboot_config/mcuboot_config.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018 Open Source Foundries Limited
- * Copyright (c) 2019 Arm Limited
+ * Copyright (c) 2019-2020 Arm Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -91,6 +91,10 @@
 
 #ifdef CONFIG_MCUBOOT_DOWNGRADE_PREVENTION
 #define MCUBOOT_DOWNGRADE_PREVENTION 1
+#endif
+
+#ifdef CONFIG_MCUBOOT_HW_DOWNGRADE_PREVENTION
+#define MCUBOOT_HW_ROLLBACK_PROT
 #endif
 
 /*

--- a/docs/design.md
+++ b/docs/design.md
@@ -18,7 +18,7 @@
 -->
 
 <!--
-  Modifications are Copyright (c) 2019 Arm Limited.
+  Modifications are Copyright (c) 2019-2020 Arm Limited.
 -->
 
 # Boot Loader
@@ -109,6 +109,7 @@ struct image_tlv {
 #define IMAGE_TLV_ENC_KW128         0x31   /* Key encrypted with AES-KW-128 */
 #define IMAGE_TLV_ENC_EC256         0x32   /* Key encrypted with ECIES P256 */
 #define IMAGE_TLV_DEPENDENCY        0x40   /* Image depends on other image */
+#define IMAGE_TLV_SEC_CNT           0x50   /* security counter */
 ```
 
 Optional type-length-value records (TLVs) containing image metadata are placed
@@ -946,7 +947,28 @@ see: [imgtool](imgtool.md).
 ## [Downgrade Prevention](#downgrade-prevention)
 
 Downgrade prevention is a feature which enforces that the new image must have a
-higher version number than the image it is replacing. This feature is enabled
-with the `MCUBOOT_DOWNGRADE_PREVENTION` option. Downgrade prevention is only
-available when the overwrite-based image update strategy is used
-(i.e. `MCUBOOT_OVERWRITE_ONLY` is set).
+higher version/security counter number than the image it is replacing, thus
+preventing the malicious downgrading of the device to an older and possibly
+vulnerable version of its firmware.
+
+### [SW Based Downgrade Prevention](#sw-downgrade-prevention)
+
+During the software based downgrade prevention the image version numbers are
+compared. This feature is enabled with the `MCUBOOT_DOWNGRADE_PREVENTION`
+option. In this case downgrade prevention is only available when the
+overwrite-based image update strategy is used (i.e. `MCUBOOT_OVERWRITE_ONLY`
+is set).
+
+### [HW Based Downgrade Prevention](#hw-downgrade-prevention)
+
+Each signed image can contain a security counter in its protected TLV area.
+During the hardware based downgrade prevention (alias rollback protection) the
+new image's security counter will be compared with the currently active security
+counter value which must be stored in a non-volatile and trusted component of
+the device. This feature is enabled with the `MCUBOOT_HW_ROLLBACK_PROT` option.
+It is beneficial to handle this counter independently from image version
+number:
+
+  * It does not need to increase with each software release,
+  * It makes it possible to do software downgrade to some extent: if the
+    security counter has the same value in the older image then it is accepted.

--- a/scripts/imgtool/image.py
+++ b/scripts/imgtool/image.py
@@ -1,6 +1,6 @@
 # Copyright 2018 Nordic Semiconductor ASA
 # Copyright 2017 Linaro Limited
-# Copyright 2019 Arm Limited
+# Copyright 2019-2020 Arm Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -61,7 +61,8 @@ TLV_VALUES = {
         'ENCRSA2048': 0x30,
         'ENCKW128': 0x31,
         'ENCEC256': 0x32,
-        'DEPENDENCY': 0x40
+        'DEPENDENCY': 0x40,
+        'SEC_CNT': 0x50,
 }
 
 TLV_SIZE = 4
@@ -119,7 +120,7 @@ class Image():
                  pad_header=False, pad=False, align=1, slot_size=0,
                  max_sectors=DEFAULT_MAX_SECTORS, overwrite_only=False,
                  endian="little", load_addr=0, erased_val=None,
-                 save_enctlv=False):
+                 save_enctlv=False, security_counter=None):
         self.version = version or versmod.decode_version("0")
         self.header_size = header_size
         self.pad_header = pad_header
@@ -137,12 +138,23 @@ class Image():
         self.save_enctlv = save_enctlv
         self.enctlv_len = 0
 
+        if security_counter == 'auto':
+            # Security counter has not been explicitly provided,
+            # generate it from the version number
+            self.security_counter = ((self.version.major << 24)
+                                     + (self.version.minor << 16)
+                                     + self.version.revision)
+        else:
+            self.security_counter = security_counter
+
     def __repr__(self):
-        return "<Image version={}, header_size={}, base_addr={}, load_addr={}, \
-                align={}, slot_size={}, max_sectors={}, overwrite_only={}, \
-                endian={} format={}, payloadlen=0x{:x}>".format(
+        return "<Image version={}, header_size={}, security_counter={}, \
+                base_addr={}, load_addr={}, align={}, slot_size={}, \
+                max_sectors={}, overwrite_only={}, endian={} format={}, \
+                payloadlen=0x{:x}>".format(
                     self.version,
                     self.header_size,
+                    self.security_counter,
                     self.base_addr if self.base_addr is not None else "N/A",
                     self.load_addr,
                     self.align,
@@ -246,14 +258,22 @@ class Image():
     def create(self, key, enckey, dependencies=None):
         self.enckey = enckey
 
-        if dependencies is None:
-            dependencies_num = 0
-            protected_tlv_size = 0
-        else:
-            # Size of a Dependency TLV = Header ('BBH') + Payload('IBBHI')
-            # = 16 Bytes
+        protected_tlv_size = 0
+
+        if self.security_counter is not None:
+            # Size of the security counter TLV: header ('HH') + payload ('I')
+            #                                   = 4 + 4 = 8 Bytes
+            protected_tlv_size += TLV_SIZE + 4
+
+        if dependencies is not None:
+            # Size of a Dependency TLV = Header ('HH') + Payload('IBBHI')
+            # = 4 + 12 = 16 Bytes
             dependencies_num = len(dependencies[DEP_IMAGES_KEY])
-            protected_tlv_size = (dependencies_num * 16) + TLV_INFO_SIZE
+            protected_tlv_size += (dependencies_num * 16)
+
+        if protected_tlv_size != 0:
+            # Add the size of the TLV info header
+            protected_tlv_size += TLV_INFO_SIZE
 
         # At this point the image is already on the payload, this adds
         # the header to the payload as well
@@ -265,17 +285,24 @@ class Image():
         # in the hash calculation
         protected_tlv_off = None
         if protected_tlv_size != 0:
-            for i in range(dependencies_num):
-                e = STRUCT_ENDIAN_DICT[self.endian]
-                payload = struct.pack(
-                                e + 'B3x'+'BBHI',
-                                int(dependencies[DEP_IMAGES_KEY][i]),
-                                dependencies[DEP_VERSIONS_KEY][i].major,
-                                dependencies[DEP_VERSIONS_KEY][i].minor,
-                                dependencies[DEP_VERSIONS_KEY][i].revision,
-                                dependencies[DEP_VERSIONS_KEY][i].build
-                                )
-                prot_tlv.add('DEPENDENCY', payload)
+
+            e = STRUCT_ENDIAN_DICT[self.endian]
+
+            if self.security_counter is not None:
+                payload = struct.pack(e + 'I', self.security_counter)
+                prot_tlv.add('SEC_CNT', payload)
+
+            if dependencies is not None:
+                for i in range(dependencies_num):
+                    payload = struct.pack(
+                                    e + 'B3x'+'BBHI',
+                                    int(dependencies[DEP_IMAGES_KEY][i]),
+                                    dependencies[DEP_VERSIONS_KEY][i].major,
+                                    dependencies[DEP_VERSIONS_KEY][i].minor,
+                                    dependencies[DEP_VERSIONS_KEY][i].revision,
+                                    dependencies[DEP_VERSIONS_KEY][i].build
+                                    )
+                    prot_tlv.add('DEPENDENCY', payload)
 
             protected_tlv_off = len(self.payload)
             self.payload += prot_tlv.get()


### PR DESCRIPTION
- Add new security counter to protected TLV area
- Add new command line option for imgtool to specify the value of this counter
- Modify the simulator to prevent the tests from failing (temporary solution)
- Make the security counter verification part of the image validation process
- Introduce security counter interface and also provide a SW only weak implementation (currently does absolutely nothing)

Related GitHub issue: #597 

Please provide feedback and ideas how it could be combined with a SW only solution (if we need it at all). Currently the verification of a new image's security counter value is mandatory.
Please see my additional comments below.