### PR TITLE
boot: zephyr: Call usb_enable() when CONFIG_USB enabled

### DIFF
--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -198,6 +198,11 @@ void main(void)
     }
 #endif
 
+#ifdef CONFIG_USB
+    rc = usb_enable(NULL);
+    __ASSERT(rc == 0, "Error initializing USB.\n");
+#endif
+
 #ifdef CONFIG_MCUBOOT_SERIAL
 
     struct device *detect_port;


### PR DESCRIPTION
USB CDC ACM wasn't being enabled on nRF52840 PCA10059 (Dongle) when booting
while holding the power button.  Adding an explicit call to usb_enable(NULL)
in main() allows the USB device to properly enumerate.

This should address issue #631 

Signed-off-by: P.J. Petree <pjpetree@gmail.com>