### PR TITLE
zephyr: fix driver include paths

### DIFF
--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -30,7 +30,7 @@
 #include <power/reboot.h>
 #include <sys/byteorder.h>
 #include <sys/__assert.h>
-#include <flash.h>
+#include <drivers/flash.h>
 #include <sys/crc.h>
 #include <sys/base64.h>
 #include <cbor.h>

--- a/boot/zephyr/flash_map_extended.c
+++ b/boot/zephyr/flash_map_extended.c
@@ -6,7 +6,7 @@
  */
 
 #include <zephyr.h>
-#include <flash.h>
+#include <drivers/flash.h>
 
 #include "target.h"
 

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -16,9 +16,9 @@
 
 #include <assert.h>
 #include <zephyr.h>
-#include <gpio.h>
+#include <drivers/gpio.h>
 #include <sys/__assert.h>
-#include <flash.h>
+#include <drivers/flash.h>
 #include <drivers/timer/system_timer.h>
 #include <usb/usb_device.h>
 #include <soc.h>

--- a/boot/zephyr/serial_adapter.c
+++ b/boot/zephyr/serial_adapter.c
@@ -15,7 +15,7 @@
  */
 
 #include <stdio.h>
-#include <uart.h>
+#include <drivers/uart.h>
 #include <assert.h>
 #include <string.h>
 #include <zephyr.h>


### PR DESCRIPTION
Zephyr will soon no longer add the drivers subdirectory of the include
hierarchy to the search path, so references to driver headers must
include the drivers/ prefix.

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>