### PR TITLE
boot: zephyr: Fix Kconfig inclusion

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -357,4 +357,4 @@ config MCUBOOT_DOWNGRADE_PREVENTION
 	  only protects against some attacks against version downgrades (for
 	  example, a JTAG could be used to write an older version).
 
-source "$ZEPHYR_BASE/Kconfig.zephyr"
+source "Kconfig.zephyr"


### PR DESCRIPTION
According to our CI:

Redundant 'source "$(ZEPHYR_BASE)/Kconfig.zephyr" in
'boot/zephyr/Kconfig'. Just do 'source "Kconfig.zephyr"'
instead. The $srctree environment variable already points
to the Zephyr root, and all 'source's are relative to it.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>