### PR TITLE
zephyr: enable usb by the application

### DIFF
--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -238,9 +238,14 @@ void main(void)
 #endif
 
 #ifdef CONFIG_BOOT_WAIT_FOR_USB_DFU
-    BOOT_LOG_INF("Waiting for USB DFU");
-    wait_for_usb_dfu();
-    BOOT_LOG_INF("USB DFU wait time elapsed");
+    rc = usb_enable(NULL);
+    if (rc) {
+        BOOT_LOG_ERR("Cannot enable USB");
+    } else {
+        BOOT_LOG_INF("Waiting for USB DFU");
+        wait_for_usb_dfu();
+        BOOT_LOG_INF("USB DFU wait time elapsed");
+    }
 #endif
 
     rc = boot_go(&rsp);

--- a/boot/zephyr/serial_adapter.c
+++ b/boot/zephyr/serial_adapter.c
@@ -20,6 +20,7 @@
 #include <string.h>
 #include <zephyr.h>
 #include "bootutil/bootutil_log.h"
+#include <usb/usb_device.h>
 
 #ifdef CONFIG_UART_CONSOLE
 #error Zephyr UART console must been disabled if serial_adapter module is used.
@@ -194,6 +195,13 @@ boot_uart_fifo_init(void)
 	uart_dev = device_get_binding(CONFIG_RECOVERY_UART_DEV_NAME);
 #elif CONFIG_BOOT_SERIAL_CDC_ACM
 	uart_dev = device_get_binding(CONFIG_USB_CDC_ACM_DEVICE_NAME "_0");
+	if (uart_dev) {
+		int rc;
+		rc = usb_enable(NULL);
+		if (rc) {
+			return (-1);
+		}
+	}
 #endif
 	u8_t c;
 


### PR DESCRIPTION
Since zephyrproject-rtos/zephyr#20375
Need to enable USB by the application.

substitute to #643

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>