### PR TITLE
Cypress: Hardware acceleration of cryptography implementation for 062 device

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "boot/cypress/libs/psoc6hal"]
 	path = boot/cypress/libs/psoc6hal
 	url = https://github.com/cypresssemiconductorco/psoc6hal.git
+[submodule "boot/cypress/libs/cy-mbedtls-acceleration"]
+	path = boot/cypress/libs/cy-mbedtls-acceleration
+	url = https://github.com/cypresssemiconductorco/cy-mbedtls-acceleration.git

--- a/boot/cypress/MCUBootApp/MCUBootApp.mk
+++ b/boot/cypress/MCUBootApp/MCUBootApp.mk
@@ -27,6 +27,7 @@
 # Set default compiler to GCC if not specified from command line
 COMPILER ?= GCC_ARM
 
+USE_CRYPTO_HW ?= 1
 MCUBOOT_IMAGE_NUMBER ?= 1
 
 ifneq ($(COMPILER), GCC_ARM)
@@ -45,6 +46,10 @@ DEFINES_APP += -DECC256_KEY_FILE="\"keys/$(SIGN_KEY_FILE).pub\""
 DEFINES_APP += -DCORE=$(CORE)
 DEFINES_APP += -DMCUBOOT_IMAGE_NUMBER=$(MCUBOOT_IMAGE_NUMBER)
 
+
+ifeq ($(USE_CRYPTO_HW), 1)
+DEFINES_APP += -DMBEDTLS_USER_CONFIG_FILE="\"mcuboot_crypto_acc_config.h\""
+endif
 # Collect MCUBoot sourses
 SOURCES_MCUBOOT := $(wildcard $(CURDIR)/../bootutil/src/*.c)
 # Collect MCUBoot Application sources

--- a/boot/cypress/MCUBootApp/README.md
+++ b/boot/cypress/MCUBootApp/README.md
@@ -23,6 +23,14 @@ Size of slots `0x10000` - 64kb
 
 MCUBootApp checks image integrity with SHA256, image authenticity with EC256 digital signature verification and uses completely SW implementation of cryptographic functions based on mbedTLS Library.
 
+**Hardware cryptography acceleration:**
+
+Cypress PSOC6 MCU family supports hardware acceleration of cryptography based on mbedTLS Library via shim layer. Implementation of this layer is supplied as separate submodule `cy-mbedtls-acceleration`. HW acceleration of cryptography shortens boot time more then 4 times, comparing to software implementation (observation results).
+
+To enable hardware acceleration in `MCUBootApp` pass flag `USE_CRYPTO_HW=1` to `make` while build.
+
+Hardware acceleration of cryptography is enabled for PSOC6 devices by default.
+
 **How to modify Flash map:**
 
 __Option 1.__

--- a/boot/cypress/MCUBootApp/config/mcuboot_crypto_acc_config.h
+++ b/boot/cypress/MCUBootApp/config/mcuboot_crypto_acc_config.h
@@ -1,0 +1,52 @@
+/*
+ * mbed Microcontroller Library
+ * Copyright (c) 2019 Cypress Semiconductor Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * \file    mcuboot_crypto_acc_config.h
+ * \version 1.1
+ */
+
+#ifndef MCUBOOT_MBEDTLS_DEVICE_H
+#define MCUBOOT_MBEDTLS_DEVICE_H
+
+/* Currently this target supports SHA1 */
+// #define MBEDTLS_SHA1_C
+
+#define MBEDTLS_SHA1_ALT
+#define MBEDTLS_SHA256_ALT
+#define MBEDTLS_SHA512_ALT
+
+/* Currently this target supports CBC, CFB, OFB, CTR and XTS cipher modes */
+#define MBEDTLS_AES_ALT
+// #define MBEDTLS_CIPHER_MODE_CBC
+// #define MBEDTLS_CIPHER_MODE_CFB
+// #define MBEDTLS_CIPHER_MODE_OFB
+// #define MBEDTLS_CIPHER_MODE_CTR
+// #define MBEDTLS_CIPHER_MODE_XTS
+
+/* Only NIST-P curves are currently supported */
+#define MBEDTLS_ECP_ALT
+// #define MBEDTLS_ECP_DP_SECP192R1_ENABLED
+// #define MBEDTLS_ECP_DP_SECP224R1_ENABLED
+// #define MBEDTLS_ECP_DP_SECP256R1_ENABLED
+// #define MBEDTLS_ECP_DP_SECP384R1_ENABLED
+// #define MBEDTLS_ECP_DP_SECP521R1_ENABLED
+
+#define MBEDTLS_ECDSA_SIGN_ALT
+#define MBEDTLS_ECDSA_VERIFY_ALT
+
+#endif /* MCUBOOT_MBEDTLS_DEVICE_H */


### PR DESCRIPTION
This PR is based on https://github.com/JuulLabs-OSS/mcuboot/pull/653

- Added hardware acceleration of MbedTLS crypto functions.
- Added one additional dependency https://github.com/cypresssemiconductorco/cy-mbedtls-acceleration.git
- Signature and hash verification performed approximately 4 times faster 
- readme updated