### PR TITLE
imgtool: fix passing --erased-val with 0xff value

### DIFF
--- a/scripts/imgtool/image.py
+++ b/scripts/imgtool/image.py
@@ -118,7 +118,7 @@ class Image():
     def __init__(self, version=None, header_size=IMAGE_HEADER_SIZE,
                  pad_header=False, pad=False, align=1, slot_size=0,
                  max_sectors=DEFAULT_MAX_SECTORS, overwrite_only=False,
-                 endian="little", load_addr=0, erased_val=0xff,
+                 endian="little", load_addr=0, erased_val=None,
                  save_enctlv=False):
         self.version = version or versmod.decode_version("0")
         self.header_size = header_size
@@ -131,7 +131,7 @@ class Image():
         self.endian = endian
         self.base_addr = None
         self.load_addr = 0 if load_addr is None else load_addr
-        self.erased_val = 0xff if erased_val is None else int(erased_val)
+        self.erased_val = 0xff if erased_val is None else int(erased_val, 0)
         self.payload = []
         self.enckey = None
         self.save_enctlv = save_enctlv


### PR DESCRIPTION
The `--erased-val` (or `-R`) option was doing conversion of base 10, so the only value that was acceptable was 0. Although not passing this option would result in the default `0xff` being used, this fixes the issue by refactoring a new function that does the heuristic conversion based on the prefix base.