### PR TITLE
kconfig: add default pin for serial recovery for nrf53

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -297,6 +297,7 @@ config BOOT_SERIAL_DETECT_PIN
 	default 6 if BOARD_NRF9160_PCA10090
 	default 11 if BOARD_NRF52840_PCA10056
 	default 13 if BOARD_NRF52_PCA10040
+	default 23 if BOARD_NRF5340_DK_NRF5340_CPUAPP || BOARD_NRF5340_DK_NRF5340_CPUAPPNS
 	help
 	  Pin on the serial detect port which triggers serial recovery mode.
 


### PR DESCRIPTION
Prior to this the kconfig would fail because of invalid value for an int

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>