### PR TITLE
zephyr: allow recovery over usb cdc-acm with logs enabled

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -357,6 +357,14 @@ config MULTITHREADING
 
 config LOG_IMMEDIATE
 	default n if MULTITHREADING
+	default y
+
+config LOG_PROCESS_THREAD
+	default n # mcuboot has its own log processing thread
+
+# override USB device name
+config USB_DEVICE_PRODUCT
+	default "MCUBOOT"
 
 config UPDATEABLE_IMAGE_NUMBER
 	int "Number of updateable images"

--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -351,8 +351,12 @@ comment "Zephyr configuration options"
 # it to n here. Otherwise, having it on by default makes the most
 # hardware work.
 config MULTITHREADING
+	default y if BOOT_SERIAL_CDC_ACM #usb driver requires MULTITHREADING
 	default n if SOC_FAMILY_NRF
 	default y
+
+config LOG_IMMEDIATE
+	default n if MULTITHREADING
 
 config UPDATEABLE_IMAGE_NUMBER
 	int "Number of updateable images"

--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -246,6 +246,18 @@ module = MCUBOOT
 module-str = MCUBoot bootloader
 source "subsys/logging/Kconfig.template.log_config"
 
+config MCUBOOT_LOG_THREAD_STACK_SIZE
+	int "Stack size for the MCUBoot log processing thread"
+	depends on LOG && !LOG_IMMEDIATE
+	default 2048 if COVERAGE_GCOV
+	default 1024 if NO_OPTIMIZATIONS
+	default 1024 if XTENSA
+	default 4096 if (X86 && X86_64)
+	default 4096 if ARM64
+	default 768
+	help
+	  Set the internal stack size for MCUBoot log processing thread.
+
 menuconfig MCUBOOT_SERIAL
 	bool "MCUboot serial recovery"
 	default n

--- a/boot/zephyr/boards/nrf52840_pca10056_big.overlay
+++ b/boot/zephyr/boards/nrf52840_pca10056_big.overlay
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &boot_partition;
+/delete-node/ &slot0_partition;
+/delete-node/ &slot1_partition;
+
+&flash0 {
+	partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			boot_partition: partition@0 {
+				label = "mcuboot";
+				reg = <0x000000000 0x00010000>;
+			};
+			slot0_partition: partition@10000 {
+				label = "image-0";
+				reg = <0x000010000 0x000074000>;
+			};
+			slot1_partition: partition@75000 {
+				label = "image-1";
+				reg = <0x00084000 0x000074000>;
+			};
+	};
+};

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -51,11 +51,10 @@ const struct boot_uart_funcs boot_funcs = {
 #else
 #include <logging/log_ctrl.h>
 
-#define BOOT_LOG_STACK_SIZE 768
 #define BOOT_LOG_PROCESSING_INTERVAL 30 /* [ms] */
 
 /* log are processing in custom routine */
-K_THREAD_STACK_DEFINE(boot_log_stack, BOOT_LOG_STACK_SIZE);
+K_THREAD_STACK_DEFINE(boot_log_stack, CONFIG_MCUBOOT_LOG_THREAD_STACK_SIZE);
 struct k_thread boot_log_thread;
 volatile bool boot_log_stop = false;
 K_SEM_DEFINE(boot_log_sem, 1, 1);

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -216,7 +216,7 @@ void main(void)
 #else
                             GPIO_DIR_IN | GPIO_PUD_PULL_UP
 #endif
-	    );
+           );
     __ASSERT(rc == 0, "Error of boot detect pin initialization.\n");
 
 #ifdef GPIO_INPUT

--- a/boot/zephyr/prj.conf
+++ b/boot/zephyr/prj.conf
@@ -45,6 +45,5 @@ CONFIG_FLASH=y
 # CONFIG_I2C is not set
 
 CONFIG_LOG=y
-CONFIG_LOG_IMMEDIATE=y
 ### Ensure Zephyr logging changes don't use more resources
 CONFIG_LOG_DEFAULT_LEVEL=0

--- a/boot/zephyr/sample.yaml
+++ b/boot/zephyr/sample.yaml
@@ -13,3 +13,8 @@ tests:
   sample.bootloader.mcuboot.usb_cdc_acm_recovery:
     tags: bootloader_mcuboot
     platform_whitelist:  nrf52840_pca10059
+  sample.bootloader.mcuboot.usb_cdc_acm_recovery_log:
+    extra_args: OVERLAY_CONFIG=./usb_cdc_acm_log_recovery.conf
+      DTC_OVERLAY=./boards/nrf52840_pca10056_big.overlay
+    platform_whitelist:  nrf52840_pca10056
+    tags: bootloader_mcuboot

--- a/boot/zephyr/serial_adapter.c
+++ b/boot/zephyr/serial_adapter.c
@@ -22,7 +22,7 @@
 #include "bootutil/bootutil_log.h"
 #include <usb/usb_device.h>
 
-#ifdef CONFIG_UART_CONSOLE
+#if defined(CONFIG_BOOT_SERIAL_UART) && defined(CONFIG_UART_CONSOLE)
 #error Zephyr UART console must been disabled if serial_adapter module is used.
 #endif
 

--- a/boot/zephyr/usb_cdc_acm_log_recovery.conf
+++ b/boot/zephyr/usb_cdc_acm_log_recovery.conf
@@ -1,0 +1,16 @@
+CONFIG_LOG=y
+
+# The build won't fit on the partition allocated for it without size
+# optimizations.
+CONFIG_SIZE_OPTIMIZATIONS=y
+
+# Serial
+CONFIG_SERIAL=y
+CONFIG_UART_LINE_CTRL=y
+
+# MCUBoot serial
+CONFIG_MCUBOOT_SERIAL=y
+CONFIG_BOOT_SERIAL_CDC_ACM=y
+
+CONFIG_LOG_BACKEND_UART=y
+CONFIG_LOG_BACKEND_RTT=n


### PR DESCRIPTION
Modyfied serial_adapter so log are alowed when using USB
CDC ACM serial port emulation.

As log needs to work asynchronously in its own thread,
mcuboot need to give some time for execution this thread using
k_sleep().

Added configuration for nrf52840_pca10056 which shows how
to enable looging along with USB - among other, thread log
processing is required.

build command (form zephyr-project root directory)
west build -d build/mcuboot/nrf52840_pca10056 -b nrf52840_pca10056
./bootloader/mcuboot/boot/zephyr/
 -- -DDTC_OVERLAY_FILE=./boards/nrf52840_pca10056_big.overlay
-DOVERLAY_CONFIG=./boards/nrf52840_pca10056_usb_cdc_log.conf

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>