### PR TITLE
mynewt: allow newt to bypass submodule cloning

### DIFF
--- a/repository.yml
+++ b/repository.yml
@@ -18,6 +18,7 @@
 #
 
 repo.name: mcuboot
+repo.submodules: ""
 repo.versions:
     "0.0.0": "master"
     "0.9.0": "v0.9.0"


### PR DESCRIPTION
A recently added `newt` feature allows it to only clone selected git submodules: https://github.com/apache/mynewt-newt/pull/377. This changes the MCUBoot repository to remove submodules from the cloning process, because they are not used by Mynewt.