### PR TITLE
docs: update nokogiri to fix CVE-2020-7595

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -205,7 +205,7 @@ GEM
       jekyll-seo-tag (~> 2.1)
     minitest (5.11.3)
     multipart-post (2.0.0)
-    nokogiri (1.10.4)
+    nokogiri (1.10.8)
       mini_portile2 (~> 2.4.0)
     octokit (4.13.0)
       sawyer (~> 0.8.0, >= 0.5.3)
@@ -244,7 +244,6 @@ PLATFORMS
 DEPENDENCIES
   github-pages
   jekyll (>= 3.7.4)
-  rubyzip (>= 1.3.0)
   tzinfo-data
 
 BUNDLED WITH


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2020-7595