### PR TITLE
Share boot data with runtime software

### DIFF
--- a/boot/bootutil/include/bootutil/boot_record.h
+++ b/boot/bootutil/include/bootutil/boot_record.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2018-2020 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __BOOT_RECORD_H__
+#define __BOOT_RECORD_H__
+
+#include <stdint.h>
+#include "bootutil/image.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Add an image's all boot status information to the shared memory area
+ * between the bootloader and runtime SW.
+ *
+ * @param[in]  sw_module  Identifier of the SW component.
+ * @param[in]  hdr        Pointer to the image header stored in RAM.
+ * @param[in]  fap        Pointer to the flash area where image is stored.
+ *
+ * @return                0 on success; nonzero on failure.
+ */
+int boot_save_boot_status(uint8_t sw_module,
+                          const struct image_header *hdr,
+                          const struct flash_area *fap);
+
+/**
+ * Add application specific data to the shared memory area between the
+ * bootloader and runtime SW.
+ *
+ * @param[in]  hdr        Pointer to the image header stored in RAM.
+ * @param[in]  fap        Pointer to the flash area where image is stored.
+ *
+ * @return                0 on success; nonzero on failure.
+ */
+int boot_save_shared_data(const struct image_header *hdr,
+                          const struct flash_area *fap);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __BOOT_RECORD_H__ */

--- a/boot/bootutil/include/bootutil/boot_status.h
+++ b/boot/bootutil/include/bootutil/boot_status.h
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2018-2020 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __BOOT_STATUS_H__
+#define __BOOT_STATUS_H__
+
+#include <stdint.h>
+#include <stddef.h>
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * The shared data between boot loader and runtime SW is TLV encoded. The
+ * shared data is stored in a well known location in memory and this is a
+ * contract between boot loader and runtime SW.
+ *
+ * The structure of shared data must be the following:
+ *  - At the beginning there must be a header: struct shared_data_tlv_header
+ *    This contains a magic number and a size field which covers the entire
+ *    size of the shared data area including this header.
+ *  - After the header there come the entries which are composed from an entry
+ *    header structure: struct shared_data_tlv_entry and the data. In the entry
+ *    header is a type field (tly_type) which identify the consumer of the
+ *    entry in the runtime SW and specify the subtype of that data item. There
+ *    is a size field (tlv_len) which covers the size of the entry header and
+ *    the data. After this structure comes the actual data.
+ *  - Arbitrary number and size of data entry can be in the shared memory area.
+ *
+ * This table gives of overview about the tlv_type field in the entry header.
+ * The tlv_type always composed from a major and minor number. Major number
+ * identifies the addressee in runtime SW, who should process the data entry.
+ * Minor number used to encode more info about the data entry. The actual
+ * definition of minor number could change per major number.
+ *
+ * In case of boot status data, which can be processed by an attestation
+ * service the minor number is split further to two part: sw_module and claim.
+ * The sw_module identifies the SW component in the system which the data item
+ * belongs to and the claim part identifies the exact type of the data.
+ *
+ * |---------------------------------------|
+ * |            tlv_type (16)              |
+ * |---------------------------------------|
+ * | tlv_major(4)|      tlv_minor(12)      |
+ * |---------------------------------------|
+ * | MAJOR_IAS   | sw_module(6) | claim(6) |
+ * |---------------------------------------|
+ */
+
+/* General macros to handle TLV type */
+#define MAJOR_MASK 0xF     /* 4  bit */
+#define MAJOR_POS  12      /* 12 bit */
+#define MINOR_MASK 0xFFF   /* 12 bit */
+
+#define SET_TLV_TYPE(major, minor) \
+        ((((major) & MAJOR_MASK) << MAJOR_POS) | ((minor) & MINOR_MASK))
+#define GET_MAJOR(tlv_type) ((tlv_type) >> MAJOR_POS)
+#define GET_MINOR(tlv_type) ((tlv_type) &  MINOR_MASK)
+
+/* Magic value which marks the beginning of shared data area in memory */
+#define SHARED_DATA_TLV_INFO_MAGIC    0x2016
+
+/* Initial attestation specific macros */
+
+/**
+ * Major numbers (4 bit) to identify the
+ * consumer of shared data in runtime SW.
+ */
+#define TLV_MAJOR_IAS      0x1
+
+/* Initial attestation: Claim per SW components / SW modules */
+/* Bits: 0-2 */
+#define SW_VERSION       0x00
+#define SW_SIGNER_ID     0x01
+/* Reserved              0x02 */
+#define SW_TYPE          0x03
+/* Bits: 3-5 */
+#define SW_MEASURE_VALUE 0x08
+#define SW_MEASURE_TYPE  0x09
+#define SW_BOOT_RECORD   0x3F
+
+#define MODULE_POS 6               /* 6 bit */
+#define CLAIM_MASK 0x3F            /* 6 bit */
+#define MEASUREMENT_CLAIM_POS 3    /* 3 bit */
+
+#define GET_IAS_MODULE(tlv_type) (GET_MINOR(tlv_type) >> MODULE_POS)
+#define GET_IAS_CLAIM(tlv_type)  (GET_MINOR(tlv_type)  & CLAIM_MASK)
+#define SET_IAS_MINOR(sw_module, claim) (((sw_module) << 6) | (claim))
+
+/**
+ * Shared data TLV header.  All fields in little endian.
+ *
+ *    -----------------------------------
+ *    | tlv_magic(16) | tlv_tot_len(16) |
+ *    -----------------------------------
+ */
+struct shared_data_tlv_header {
+    uint16_t tlv_magic;
+    uint16_t tlv_tot_len; /* size of whole TLV area (including this header) */
+};
+
+#define SHARED_DATA_HEADER_SIZE sizeof(struct shared_data_tlv_header)
+
+/**
+ * Shared data TLV entry header format. All fields in little endian.
+ *
+ *    -------------------------------
+ *    | tlv_type(16) |  tlv_len(16) |
+ *    -------------------------------
+ *    |         Raw data            |
+ *    -------------------------------
+ */
+struct shared_data_tlv_entry {
+    uint16_t tlv_type;
+    uint16_t tlv_len; /* size of single TLV entry (including this header). */
+};
+
+#define SHARED_DATA_ENTRY_HEADER_SIZE sizeof(struct shared_data_tlv_entry)
+#define SHARED_DATA_ENTRY_SIZE(size) (size + SHARED_DATA_ENTRY_HEADER_SIZE)
+
+/* Structure to store the boot data for the runtime SW. */
+struct shared_boot_data {
+    struct shared_data_tlv_header header;
+    uint8_t data[];
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __BOOT_STATUS_H__ */

--- a/boot/bootutil/include/bootutil/image.h
+++ b/boot/bootutil/include/bootutil/image.h
@@ -85,6 +85,7 @@ struct flash_area;
 #define IMAGE_TLV_ENC_EC256         0x32   /* Key encrypted with ECIES-EC256 */
 #define IMAGE_TLV_DEPENDENCY        0x40   /* Image depends on other image */
 #define IMAGE_TLV_SEC_CNT           0x50   /* security counter */
+#define IMAGE_TLV_BOOT_RECORD       0x60   /* measured boot record */
 #define IMAGE_TLV_ANY               0xffff /* Used to iterate over all TLV */
 
 struct image_version {

--- a/boot/bootutil/src/boot_record.c
+++ b/boot/bootutil/src/boot_record.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2020 Arm Limited
+ * Copyright (c) 2020 Linaro Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -87,21 +88,23 @@ boot_add_data_to_shared_area(uint8_t        major_type,
     /* Iterates over the TLV section looks for the same entry if found then
      * returns with error: SHARED_MEMORY_OVERWRITE
      */
-    for (; offset < tlv_end; offset += tlv_entry.tlv_len) {
+    while (offset < tlv_end) {
         /* Create local copy to avoid unaligned access */
         memcpy(&tlv_entry, (const void *)offset, SHARED_DATA_ENTRY_HEADER_SIZE);
         if (GET_MAJOR(tlv_entry.tlv_type) == major_type &&
             GET_MINOR(tlv_entry.tlv_type) == minor_type) {
             return SHARED_MEMORY_OVERWRITE;
         }
+
+        offset += SHARED_DATA_ENTRY_SIZE(tlv_entry.tlv_len);
     }
 
     /* Add TLV entry */
     tlv_entry.tlv_type = SET_TLV_TYPE(major_type, minor_type);
-    tlv_entry.tlv_len  = SHARED_DATA_ENTRY_SIZE(size);
+    tlv_entry.tlv_len  = size;
 
     if (!boot_u16_safe_add(&boot_data_size, boot_data->header.tlv_tot_len,
-                           tlv_entry.tlv_len)) {
+                           SHARED_DATA_ENTRY_SIZE(size))) {
         return SHARED_MEMORY_GEN_ERROR;
     }
 
@@ -116,7 +119,7 @@ boot_add_data_to_shared_area(uint8_t        major_type,
     offset += SHARED_DATA_ENTRY_HEADER_SIZE;
     memcpy((void *)offset, data, size);
 
-    boot_data->header.tlv_tot_len += tlv_entry.tlv_len;
+    boot_data->header.tlv_tot_len += SHARED_DATA_ENTRY_SIZE(size);
 
     return SHARED_MEMORY_OK;
 }

--- a/boot/bootutil/src/boot_record.c
+++ b/boot/bootutil/src/boot_record.c
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 2018-2020 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <limits.h>
+#include <stdbool.h>
+#include <string.h>
+
+#include "mcuboot_config/mcuboot_config.h"
+
+#if defined(MCUBOOT_MEASURED_BOOT) || defined(MCUBOOT_DATA_SHARING)
+#include "bootutil/boot_record.h"
+#include "bootutil/boot_status.h"
+#include "bootutil_priv.h"
+#include "bootutil/image.h"
+#include "flash_map_backend/flash_map_backend.h"
+
+/* Error codes for using the shared memory area. */
+#define SHARED_MEMORY_OK            (0)
+#define SHARED_MEMORY_OVERFLOW      (1)
+#define SHARED_MEMORY_OVERWRITE     (2)
+#define SHARED_MEMORY_GEN_ERROR     (3)
+
+/**
+ * @var shared_memory_init_done
+ *
+ * @brief Indicates whether shared memory area was already initialized.
+ *
+ */
+static bool shared_memory_init_done;
+
+/**
+ * @brief Add a data item to the shared data area between bootloader and
+ *        runtime SW
+ *
+ * @param[in] major_type  TLV major type, identify consumer
+ * @param[in] minor_type  TLV minor type, identify TLV type
+ * @param[in] size        length of added data
+ * @param[in] data        pointer to data
+ *
+ * @return                0 on success; nonzero on failure.
+ */
+static int
+boot_add_data_to_shared_area(uint8_t        major_type,
+                             uint16_t       minor_type,
+                             size_t         size,
+                             const uint8_t *data)
+{
+    struct shared_data_tlv_entry tlv_entry = {0};
+    struct shared_boot_data *boot_data;
+    uint16_t boot_data_size;
+    uintptr_t tlv_end, offset;
+
+    boot_data = (struct shared_boot_data *)MCUBOOT_SHARED_DATA_BASE;
+
+    /* Check whether first time to call this function. If does then initialise
+     * shared data area.
+     */
+    if (!shared_memory_init_done) {
+        memset((void *)MCUBOOT_SHARED_DATA_BASE, 0, MCUBOOT_SHARED_DATA_SIZE);
+        boot_data->header.tlv_magic   = SHARED_DATA_TLV_INFO_MAGIC;
+        boot_data->header.tlv_tot_len = SHARED_DATA_HEADER_SIZE;
+        shared_memory_init_done = true;
+    }
+
+    /* Check whether TLV entry is already added.
+     * Get the boundaries of TLV section
+     */
+    tlv_end = MCUBOOT_SHARED_DATA_BASE + boot_data->header.tlv_tot_len;
+    offset  = MCUBOOT_SHARED_DATA_BASE + SHARED_DATA_HEADER_SIZE;
+
+    /* Iterates over the TLV section looks for the same entry if found then
+     * returns with error: SHARED_MEMORY_OVERWRITE
+     */
+    for (; offset < tlv_end; offset += tlv_entry.tlv_len) {
+        /* Create local copy to avoid unaligned access */
+        memcpy(&tlv_entry, (const void *)offset, SHARED_DATA_ENTRY_HEADER_SIZE);
+        if (GET_MAJOR(tlv_entry.tlv_type) == major_type &&
+            GET_MINOR(tlv_entry.tlv_type) == minor_type) {
+            return SHARED_MEMORY_OVERWRITE;
+        }
+    }
+
+    /* Add TLV entry */
+    tlv_entry.tlv_type = SET_TLV_TYPE(major_type, minor_type);
+    tlv_entry.tlv_len  = SHARED_DATA_ENTRY_SIZE(size);
+
+    if (!boot_u16_safe_add(&boot_data_size, boot_data->header.tlv_tot_len,
+                           tlv_entry.tlv_len)) {
+        return SHARED_MEMORY_GEN_ERROR;
+    }
+
+    /* Verify overflow of shared area */
+    if (boot_data_size > MCUBOOT_SHARED_DATA_SIZE) {
+        return SHARED_MEMORY_OVERFLOW;
+    }
+
+    offset = tlv_end;
+    memcpy((void *)offset, &tlv_entry, SHARED_DATA_ENTRY_HEADER_SIZE);
+
+    offset += SHARED_DATA_ENTRY_HEADER_SIZE;
+    memcpy((void *)offset, data, size);
+
+    boot_data->header.tlv_tot_len += tlv_entry.tlv_len;
+
+    return SHARED_MEMORY_OK;
+}
+#endif /* MCUBOOT_MEASURED_BOOT OR MCUBOOT_DATA_SHARING */
+
+#ifdef MCUBOOT_MEASURED_BOOT
+/* See in boot_record.h */
+int
+boot_save_boot_status(uint8_t sw_module,
+                      const struct image_header *hdr,
+                      const struct flash_area *fap)
+{
+
+    struct image_tlv_iter it;
+    uint32_t offset;
+    uint16_t len;
+    uint16_t type;
+    uint16_t ias_minor;
+    size_t record_len = 0;
+    uint8_t image_hash[32]; /* SHA256 - 32 Bytes */
+    uint8_t buf[MAX_BOOT_RECORD_SZ];
+    bool boot_record_found = false;
+    bool hash_found = false;
+    int rc;
+
+    /* Manifest data is concatenated to the end of the image.
+     * It is encoded in TLV format.
+     */
+
+    rc = bootutil_tlv_iter_begin(&it, hdr, fap, IMAGE_TLV_ANY, false);
+    if (rc) {
+        return -1;
+    }
+
+    /* Traverse through the TLV area to find the boot record
+     * and image hash TLVs.
+     */
+    while (true) {
+        rc = bootutil_tlv_iter_next(&it, &offset, &len, &type);
+        if (rc < 0) {
+            return -1;
+        } else if (rc > 0) {
+            break;
+        }
+
+        if (type == IMAGE_TLV_BOOT_RECORD) {
+            if (len > sizeof(buf)) {
+                return -1;
+            }
+            rc = flash_area_read(fap, offset, buf, len);
+            if (rc) {
+                return -1;
+            }
+
+            record_len = len;
+            boot_record_found = true;
+
+        } else if (type == IMAGE_TLV_SHA256) {
+            /* Get the image's hash value from the manifest section. */
+            if (len > sizeof(image_hash)) {
+                return -1;
+            }
+            rc = flash_area_read(fap, offset, image_hash, len);
+            if (rc) {
+                return -1;
+            }
+
+            hash_found = true;
+
+            /* The boot record TLV is part of the protected TLV area which is
+             * located before the other parts of the TLV area (including the
+             * image hash) so at this point it is okay to break the loop
+             * as the boot record TLV should have already been found.
+             */
+            break;
+        }
+    }
+
+
+    if (!boot_record_found || !hash_found) {
+        return -1;
+    }
+
+    /* Update the measurement value (hash of the image) data item in the
+     * boot record. It is always the last item in the structure to make
+     * it easy to calculate its position.
+     * The image hash is computed over the image header, the image itself and
+     * the protected TLV area (which should already include the image hash as
+     * part of the boot record TLV). For this reason this field has been
+     * filled with zeros during the image signing process.
+     */
+    offset = record_len - sizeof(image_hash);
+    /* The size of 'buf' has already been checked when
+     * the BOOT_RECORD TLV was read, it won't overflow.
+     */
+    memcpy(buf + offset, image_hash, sizeof(image_hash));
+
+    /* Add the CBOR encoded boot record to the shared data area. */
+    ias_minor = SET_IAS_MINOR(sw_module, SW_BOOT_RECORD);
+    rc = boot_add_data_to_shared_area(TLV_MAJOR_IAS,
+                                      ias_minor,
+                                      record_len,
+                                      buf);
+    if (rc != SHARED_MEMORY_OK) {
+        return rc;
+    }
+
+    return 0;
+}
+#endif /* MCUBOOT_MEASURED_BOOT */

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -39,6 +39,7 @@
 #include "swap_priv.h"
 #include "bootutil/bootutil_log.h"
 #include "bootutil/security_cnt.h"
+#include "bootutil/boot_record.h"
 
 #ifdef MCUBOOT_ENC_IMAGES
 #include "bootutil/enc_key.h"
@@ -1788,6 +1789,24 @@ context_boot_go(struct boot_loader_state *state, struct boot_rsp *rsp)
             }
         }
 #endif /* MCUBOOT_HW_ROLLBACK_PROT */
+
+#ifdef MCUBOOT_MEASURED_BOOT
+        rc = boot_save_boot_status(BOOT_CURR_IMG(state),
+                                   boot_img_hdr(state, BOOT_PRIMARY_SLOT),
+                                   BOOT_IMG_AREA(state, BOOT_PRIMARY_SLOT));
+        if (rc != 0) {
+            BOOT_LOG_ERR("Failed to add Image %u data to shared memory area",
+                         BOOT_CURR_IMG(state));
+        }
+#endif /* MCUBOOT_MEASURED_BOOT */
+
+#ifdef MCUBOOT_DATA_SHARING
+        rc = boot_save_shared_data(boot_img_hdr(state, BOOT_PRIMARY_SLOT),
+                                   BOOT_IMG_AREA(state, BOOT_PRIMARY_SLOT));
+        if (rc != 0) {
+            BOOT_LOG_ERR("Failed to add data to shared memory area.");
+        }
+#endif /* MCUBOOT_DATA_SHARING */
     }
 
 #if (BOOT_IMAGE_NUMBER > 1)

--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -217,6 +217,18 @@ config BOOT_ERASE_PROGRESSIVELY
 	 on some hardware that has long erase times, to prevent long wait
 	 times at the beginning of the DFU process.
 
+config MEASURED_BOOT
+	bool "Store the boot state/measurements in shared memory"
+	default n
+	help
+	  If enabled, the bootloader will store certain boot measurements such as
+	  the hash of the firmware image in a shared memory area. This data can
+	  be used later by runtime services (e.g. by a device attestation service).
+
+config BOOT_SHARE_DATA
+	bool "Save application specific data in shared memory area"
+	default n
+
 config BOOT_WAIT_FOR_USB_DFU
 	bool "Wait for a prescribed duration to see if USB DFU is invoked"
 	default n

--- a/boot/zephyr/include/mcuboot_config/mcuboot_config.h
+++ b/boot/zephyr/include/mcuboot_config/mcuboot_config.h
@@ -97,6 +97,14 @@
 #define MCUBOOT_HW_ROLLBACK_PROT
 #endif
 
+#ifdef CONFIG_MEASURED_BOOT
+#define MCUBOOT_MEASURED_BOOT
+#endif
+
+#ifdef CONFIG_BOOT_SHARE_DATA
+#define MCUBOOT_DATA_SHARING
+#endif
+
 /*
  * Enabling this option uses newer flash map APIs. This saves RAM and
  * avoids deprecated API usage.

--- a/scripts/imgtool.nix
+++ b/scripts/imgtool.nix
@@ -19,6 +19,7 @@ let
       python37.pkgs.cryptography
       python37.pkgs.intelhex
       python37.pkgs.setuptools
+      python37.pkgs.cbor
     ]
   );
 in

--- a/scripts/imgtool/__init__.py
+++ b/scripts/imgtool/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-imgtool_version = "1.5.0"
+imgtool_version = "1.6.0a1"

--- a/scripts/imgtool/boot_record.py
+++ b/scripts/imgtool/boot_record.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2019, Arm Limited.
+# Copyright (c) 2020, Linaro Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from enum import Enum
+import cbor
+
+
+class SwComponent(int, Enum):
+    """
+    Software component property IDs specified by
+    Arm's PSA Attestation API 1.0 document.
+    """
+    TYPE = 1
+    MEASUREMENT_VALUE = 2
+    VERSION = 4
+    SIGNER_ID = 5
+    MEASUREMENT_DESCRIPTION = 6
+
+
+def create_sw_component_data(sw_type, sw_version, sw_measurement_description,
+                             sw_measurement_value, sw_signer_id):
+
+    # List of software component properties (Key ID + value)
+    properties = {
+        SwComponent.TYPE: sw_type,
+        SwComponent.VERSION: sw_version,
+        SwComponent.SIGNER_ID: sw_signer_id,
+        SwComponent.MEASUREMENT_DESCRIPTION: sw_measurement_description,
+    }
+
+    # Note: The measurement value must be the last item of the property
+    #       list because later it will be modified by the bootloader.
+    properties[SwComponent.MEASUREMENT_VALUE] = sw_measurement_value
+
+    return cbor.dumps(properties)

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,3 +1,4 @@
 cryptography>=2.6
 intelhex
 click
+cbor>=1.0.0

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -10,10 +10,12 @@ setuptools.setup(
     license="Apache Software License",
     url="http://github.com/JuulLabs-OSS/mcuboot",
     packages=setuptools.find_packages(),
+    python_requires='>=3.6',
     install_requires=[
         'cryptography>=2.4.2',
         'intelhex>=2.2.1',
         'click',
+        'cbor>=1.0.0',
     ],
     entry_points={
         "console_scripts": ["imgtool=imgtool.main:imgtool"]


### PR DESCRIPTION
This patch enables measured boot by implementing an interface for mcuboot to share various attributes/measurement of the authenticated images (boot data) with the runtime software (sharing arbitrary data is also possible). As a result it also creates the prerequisites for an attestation service
(runtime) by preserving this data from the boot stage.

The imgtool was updated to optionally add a new type of TLV to the image manifest with all the attributes and measurements that are known at build time. Before adding this data to the TLV area it is encoded in CBOR format. Later mcuboot will read and update this binary data and add it to a shared memory area between the bootloader and runtime software.

The list of shared measurements is based on the recommendations of Arm's Platform Security Architecture (PSA) (https://developer.arm.com/architectures/security-architectures/platform-security-architecture) because another purpose of this patch is to support compliance with it. By encoding part of the boot data at build time the increase in code size can be minimized and the CBOR encoded data can be used directly later in the creation of an initial attestation token which is also required by PSA.