### PR TITLE
Update instructions to point to correct git URL

### DIFF
--- a/boot/cypress/README.md
+++ b/boot/cypress/README.md
@@ -34,11 +34,11 @@ Those are represented as submodules.
 
 To retrieve source code with subsequent submodules pull:
 
-    git clone --recursive http://git-ore.aus.cypress.com/repo/cy_mcuboot_project/cy_mcuboot.git
+    git clone --recursive https://github.com/JuulLabs-OSS/mcuboot.git
 
 Submodules can also be updated and initialized separately:
 
-    cd cy_mcuboot
+    cd mcuboot
     git submodule update --init --recursive
 
 
@@ -64,7 +64,7 @@ Root directory for build is **boot/cypress.**
 Following CLI / IDE are supported for project build:
 
 * Cygwin on Windows systems
-* unix style sheels on *nix systems
+* unix style shells on *nix systems
 * Eclipse / ModusToolbox ("makefile project from existing source")
 
 *Make* - make sure it is added to system's `PATH` variable and correct path is first in the list;


### PR DESCRIPTION
Updating the URL for git repository in README file to reflect merge
of PSoC62 into mcuboot master.