### PR TITLE
fix #675 ECDSA verification fail when padding is added

### DIFF
--- a/scripts/imgtool/keys/ecdsa.py
+++ b/scripts/imgtool/keys/ecdsa.py
@@ -61,6 +61,8 @@ class ECDSA256P1Public(KeyClass):
         return 72
 
     def verify(self, signature, payload):
+        # strip possible paddings added during sign
+        signature = signature[:signature[1] + 2]
         k = self.key
         if isinstance(self.key, ec.EllipticCurvePrivateKey):
             k = self.key.public_key()


### PR DESCRIPTION
The sign method may add 1 or 2 '\0' character padding to ensure the signature TLV is 72 bytes. But the verification function didn't strip the paddings before invoking crypto libraries. It causes failure when the signature is 70 or 71 bytes.