### PR TITLE
Remove default padding from ECDSA signatures

### DIFF
--- a/scripts/imgtool/keys/ecdsa.py
+++ b/scripts/imgtool/keys/ecdsa.py
@@ -52,12 +52,17 @@ class ECDSA256P1Public(KeyClass):
         return "ECDSA256"
 
     def sig_len(self):
-        # The DER encoding depends on the high bit, and can be
-        # anywhere from 70 to 72 bytes.  Because we have to fill in
-        # the length field before computing the signature, however,
-        # we'll give the largest, and the sig checking code will allow
-        # for it to be up to two bytes larger than the actual
-        # signature.
+        # Early versions of MCUboot (< v1.5.0) required ECDSA
+        # signatures to be padded to 72 bytes.  Because the DER
+        # encoding is done with signed integers, the size of the
+        # signature will vary depending on whether the high bit is set
+        # in each value.  This padding was done in a
+        # not-easily-reversible way (by just adding zeros).
+        #
+        # The signing code no longer requires this padding, and newer
+        # versions of MCUboot don't require it.  But, continue to
+        # return the total length so that the padding can be done if
+        # requested.
         return 72
 
     def verify(self, signature, payload):
@@ -76,6 +81,7 @@ class ECDSA256P1(ECDSA256P1Public):
     def __init__(self, key):
         """key should be an instance of EllipticCurvePrivateKey"""
         self.key = key
+        self.pad_sig = False
 
     @staticmethod
     def generate():
@@ -140,7 +146,10 @@ class ECDSA256P1(ECDSA256P1Public):
                 signature_algorithm=ec.ECDSA(SHA256()))
 
     def sign(self, payload):
-        # To make fixed length, pad with one or two zeros.
         sig = self.raw_sign(payload)
-        sig += b'\000' * (self.sig_len() - len(sig))
-        return sig
+        if self.pad_sig:
+            # To make fixed length, pad with one or two zeros.
+            sig += b'\000' * (self.sig_len() - len(sig))
+            return sig
+        else:
+            return sig

--- a/scripts/imgtool/main.py
+++ b/scripts/imgtool/main.py
@@ -244,6 +244,9 @@ class BasedIntParamType(click.ParamType):
                    'image')
 @click.option('-H', '--header-size', callback=validate_header_size,
               type=BasedIntParamType(), required=True)
+@click.option('--pad-sig', default=False, is_flag=True,
+              help='Add 0-2 bytes of padding to ECDSA signature '
+                   '(for mcuboot <1.5)')
 @click.option('-d', '--dependencies', callback=get_dependencies,
               required=False, help='''Add dependence on another image, format:
               "(<image_ID>,<image_version>), ... "''')
@@ -257,7 +260,7 @@ class BasedIntParamType(click.ParamType):
 @click.command(help='''Create a signed or unsigned image\n
                INFILE and OUTFILE are parsed as Intel HEX if the params have
                .hex extension, otherwise binary format is used''')
-def sign(key, align, version, header_size, pad_header, slot_size, pad, confirm,
+def sign(key, align, version, pad_sig, header_size, pad_header, slot_size, pad, confirm,
          max_sectors, overwrite_only, endian, encrypt, infile, outfile,
          dependencies, load_addr, hex_addr, erased_val, save_enctlv,
          security_counter):
@@ -279,6 +282,10 @@ def sign(key, align, version, header_size, pad_header, slot_size, pad, confirm,
             # FIXME
             raise click.UsageError("Signing and encryption must use the same "
                                    "type of key")
+
+    if pad_sig and hasattr(key, 'pad_sig'):
+        key.pad_sig = True
+
     img.create(key, enckey, dependencies)
     img.save(outfile, hex_addr)
 

--- a/sim/src/tlv.rs
+++ b/sim/src/tlv.rs
@@ -412,12 +412,7 @@ impl ManifestGen for TlvGen {
 
             result.write_u16::<LittleEndian>(TlvKinds::ECDSA256 as u16).unwrap();
 
-
-            // signature must be padded...
-            let mut signature = signature.as_ref().to_vec();
-            while signature.len() < 72 {
-                signature.push(0);
-            }
+            let signature = signature.as_ref().to_vec();
 
             result.write_u16::<LittleEndian>(signature.len() as u16).unwrap();
             result.extend_from_slice(signature.as_ref());


### PR DESCRIPTION
Continuing from #621, make non padded ECDSA signatures the default. The `--pad-sig` flag is added to imgtool to be able to make images for old versions of MCUboot.