### PR TITLE
imgtool: add option for confirming a padded image

### DIFF
--- a/scripts/imgtool/image.py
+++ b/scripts/imgtool/image.py
@@ -117,14 +117,15 @@ class TLV():
 class Image():
 
     def __init__(self, version=None, header_size=IMAGE_HEADER_SIZE,
-                 pad_header=False, pad=False, align=1, slot_size=0,
-                 max_sectors=DEFAULT_MAX_SECTORS, overwrite_only=False,
-                 endian="little", load_addr=0, erased_val=None,
-                 save_enctlv=False, security_counter=None):
+                 pad_header=False, pad=False, confirm=False, align=1,
+                 slot_size=0, max_sectors=DEFAULT_MAX_SECTORS,
+                 overwrite_only=False, endian="little", load_addr=0,
+                 erased_val=None, save_enctlv=False, security_counter=None):
         self.version = version or versmod.decode_version("0")
         self.header_size = header_size
         self.pad_header = pad_header
         self.pad = pad
+        self.confirm = confirm
         self.align = align
         self.slot_size = slot_size
         self.max_sectors = max_sectors
@@ -432,8 +433,10 @@ class Image():
                                    self.overwrite_only, self.enckey,
                                    self.save_enctlv, self.enctlv_len)
         padding = size - (len(self.payload) + tsize)
-        pbytes = bytes([self.erased_val] * padding)
-        pbytes += bytes([self.erased_val] * (tsize - len(boot_magic)))
+        pbytes = bytearray([self.erased_val] * padding)
+        pbytes += bytearray([self.erased_val] * (tsize - len(boot_magic)))
+        if self.confirm and not self.overwrite_only:
+            pbytes[-MAX_ALIGN] = 0x01  # image_ok = 0x01
         pbytes += boot_magic
         self.payload += pbytes
 

--- a/scripts/imgtool/main.py
+++ b/scripts/imgtool/main.py
@@ -233,6 +233,8 @@ class BasedIntParamType(click.ParamType):
 @click.option('-M', '--max-sectors', type=int,
               help='When padding allow for this amount of sectors (defaults '
                    'to 128)')
+@click.option('--confirm', default=False, is_flag=True,
+              help='When padding the image, mark it as confirmed')
 @click.option('--pad', default=False, is_flag=True,
               help='Pad image to --slot-size bytes, adding trailer magic')
 @click.option('-S', '--slot-size', type=BasedIntParamType(), required=True,
@@ -255,15 +257,15 @@ class BasedIntParamType(click.ParamType):
 @click.command(help='''Create a signed or unsigned image\n
                INFILE and OUTFILE are parsed as Intel HEX if the params have
                .hex extension, otherwise binary format is used''')
-def sign(key, align, version, header_size, pad_header, slot_size, pad,
+def sign(key, align, version, header_size, pad_header, slot_size, pad, confirm,
          max_sectors, overwrite_only, endian, encrypt, infile, outfile,
          dependencies, load_addr, hex_addr, erased_val, save_enctlv,
          security_counter):
     img = image.Image(version=decode_version(version), header_size=header_size,
-                      pad_header=pad_header, pad=pad, align=int(align),
-                      slot_size=slot_size, max_sectors=max_sectors,
-                      overwrite_only=overwrite_only, endian=endian,
-                      load_addr=load_addr, erased_val=erased_val,
+                      pad_header=pad_header, pad=pad, confirm=confirm,
+                      align=int(align), slot_size=slot_size,
+                      max_sectors=max_sectors, overwrite_only=overwrite_only,
+                      endian=endian, load_addr=load_addr, erased_val=erased_val,
                       save_enctlv=save_enctlv,
                       security_counter=security_counter)
     img.load(infile)


### PR DESCRIPTION
Add imgtool command line option for confirming (setting image_ok = 0x01) in a padded image.

Fixes: #664

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>