### PR TITLE
zephyr: cleanup of ARM core before application boot

### DIFF
--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -228,3 +228,8 @@ if(NOT CONFIG_BOOT_SIGNATURE_KEY_FILE STREQUAL "")
   zephyr_library_sources(${GENERATED_PUBKEY})
 endif()
 
+if(CONFIG_MCUBOOT_CLEANUP_ARM_CORE)
+zephyr_library_sources(
+  ${BOOT_DIR}/zephyr/arm_cleanup.c
+)
+endif()

--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -120,6 +120,11 @@ config BOOT_SIGNATURE_KEY_FILE
 	  with the public key information will be written in a format expected by
 	  MCUboot.
 
+config MCUBOOT_CLEANUP_ARM_CORE
+	bool "Perform core cleanup before chain-load the application"
+	depends on CPU_CORTEX_M
+	default y
+
 config MBEDTLS_CFG_FILE
 	default "mcuboot-mbedtls-cfg.h"
 

--- a/boot/zephyr/arm_cleanup.c
+++ b/boot/zephyr/arm_cleanup.c
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr.h>
+
+void cleanup_arm_nvic(void) {
+	/* Allow any pending interrupts to be recognized */
+	__ISB();
+	__disable_irq();
+
+	/* Disable NVIC interrupts */
+	for (u8_t i = 0; i < ARRAY_SIZE(NVIC->ICER); i++) {
+		NVIC->ICER[i] = 0xFFFFFFFF;
+	}
+	/* Clear pending NVIC interrupts */
+	for (u8_t i = 0; i < ARRAY_SIZE(NVIC->ICPR); i++) {
+		NVIC->ICPR[i] = 0xFFFFFFFF;
+	}
+}

--- a/boot/zephyr/include/arm_cleanup.h
+++ b/boot/zephyr/include/arm_cleanup.h
@@ -1,0 +1,15 @@
+
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef H_ARM_CLEANUP_
+#define H_ARM_CLEANUP_
+
+/**
+ * Cleanup interrupt priority and interupt enable registers.
+ */
+void cleanup_arm_nvic(void);
+#endif

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -44,6 +44,10 @@ const struct boot_uart_funcs boot_funcs = {
 #include <usb/class/usb_dfu.h>
 #endif
 
+#if CONFIG_MCUBOOT_CLEANUP_ARM_CORE
+#include <arm_cleanup.h>
+#endif
+
 #if defined(CONFIG_LOG) && !defined(CONFIG_LOG_IMMEDIATE)
 #ifdef CONFIG_LOG_PROCESS_THREAD
 #warning "The log internal thread for log processing can't transfer the log"\
@@ -126,7 +130,13 @@ static void do_boot(struct boot_rsp *rsp)
     /* Disable the USB to prevent it from firing interrupts */
     usb_disable();
 #endif
+#if CONFIG_MCUBOOT_CLEANUP_ARM_CORE
+    cleanup_arm_nvic(); /* cleanup NVIC registers */
+#endif
     __set_MSP(vt->msp);
+#if CONFIG_MCUBOOT_CLEANUP_ARM_CORE
+    __set_CONTROL(0x00); /* application will configures core on its own */
+#endif
     ((void (*)(void))vt->reset)();
 }
 


### PR DESCRIPTION
This patch is needed as MCUBoot should be able to chain-load any
application, not only these built using zephyr.

Introduced cleanup on ARM core control register.
Might be required as for instance the application assumes
that it starts with thread mode configured as by default, not
according to zephyr-rtos configuration.

MCUBoot disables interrupt before application chain-load used
basepr register. This Patch introduce additional celenup on
NVIC register.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>