### PR TITLE
zephyr: TinyCBOR has been removed from interface libraries

### DIFF
--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -196,11 +196,6 @@ if(CONFIG_MCUBOOT_SERIAL)
   zephyr_include_directories(${BOOT_DIR}/boot_serial/include)
   zephyr_include_directories(include)
 
-  zephyr_link_libraries_ifdef(
-    CONFIG_TINYCBOR
-    TINYCBOR
-    )
-
   zephyr_include_directories_ifdef(
     CONFIG_BOOT_ERASE_PROGRESSIVELY
     ${BOOT_DIR}/bootutil/src


### PR DESCRIPTION
DEPENDS ON:
https://github.com/zephyrproject-rtos/tinycbor/pull/13

It is no longer needed to add TINYCBOR to list of interface libraries.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>