### PR TITLE
Revert "bootutil: Replace BUILD_ASSERT_MSG() with BUILD_ASSERT()"

### DIFF
--- a/boot/bootutil/include/bootutil/image.h
+++ b/boot/bootutil/include/bootutil/image.h
@@ -133,8 +133,8 @@ struct image_tlv {
     ((fap)->fa_id == FLASH_AREA_IMAGE_SECONDARY(idx) && IS_ENCRYPTED(hdr))
 
 #ifdef __ZEPHYR__
-BUILD_ASSERT(sizeof(struct image_header) == IMAGE_HEADER_SIZE,
-	     "struct image_header not required size");
+BUILD_ASSERT_MSG(sizeof(struct image_header) == IMAGE_HEADER_SIZE,
+               "struct image_header not required size");
 #else
 _Static_assert(sizeof(struct image_header) == IMAGE_HEADER_SIZE,
                "struct image_header not required size");


### PR DESCRIPTION
This reverts commit 6d417c9c84f347e275146cf8b11c02373a1eb831.

The patch was merged accidentally too early.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>