### PR TITLE
zephyr: Wrap sleep value with K_MSEC

### DIFF
--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -55,7 +55,7 @@ const struct boot_uart_funcs boot_funcs = {
 #else
 #include <logging/log_ctrl.h>
 
-#define BOOT_LOG_PROCESSING_INTERVAL 30 /* [ms] */
+#define BOOT_LOG_PROCESSING_INTERVAL K_MSEC(30) /* [ms] */
 
 /* log are processing in custom routine */
 K_THREAD_STACK_DEFINE(boot_log_stack, CONFIG_MCUBOOT_LOG_THREAD_STACK_SIZE);


### PR DESCRIPTION
Zephyr timeout API is changing and will use opaque value (k_timeout_t)
instead of raw values. K_MSEC is used to convert raw milliseconds value
to k_timeout_t.

This change is backward compatible so can be merged independently.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>