### PR TITLE
zephyr: boot_serial: Use K_MSEC() with k_sleep

### DIFF
--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -404,7 +404,7 @@ bs_reset(char *buf, int len)
     bs_empty_rsp(buf, len);
 
 #ifdef __ZEPHYR__
-    k_sleep(250);
+    k_sleep(K_MSEC(250));
     sys_reboot(SYS_REBOOT_COLD);
 #else
     os_cputime_delay_usecs(250000);


### PR DESCRIPTION
k_sleep() requires explicit conversion of the unit since it takes an
opaque type starting with:
https://github.com/zephyrproject-rtos/zephyr/pull/23382

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>