### PR TITLE
zephyr: Use K_MSEC in k_sleep call

### DIFF
--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -404,7 +404,7 @@ bs_reset(char *buf, int len)
     bs_empty_rsp(buf, len);
 
 #ifdef __ZEPHYR__
-    k_sleep(250);
+    k_sleep(K_MSEC(250));
     sys_reboot(SYS_REBOOT_COLD);
 #else
     os_cputime_delay_usecs(250000);


### PR DESCRIPTION
Zephyr timeout API is changing and will use opaque value (k_timeout_t)
instead of raw values. K_MSEC is used to convert raw milliseconds value
to k_timeout_t.

This change is backward compatible so can be merged independently.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>