### PR TITLE
scripts: assemble.py: switch to using devicetree_legacy_unfixed.h

### DIFF
--- a/scripts/assemble.py
+++ b/scripts/assemble.py
@@ -50,7 +50,7 @@ class Assembly():
     def find_slots(self, bootdir):
         offsets = {}
         sizes = {}
-        with open(os.path.join(bootdir, 'zephyr', 'include', 'generated', 'devicetree_unfixed.h'), 'r') as fd:
+        with open(os.path.join(bootdir, 'zephyr', 'include', 'generated', 'devicetree_legacy_unfixed.h'), 'r') as fd:
             for line in fd:
                 m = offset_re.match(line)
                 if m is not None:


### PR DESCRIPTION
Switch to using the devicetree_legacy_unfixed.h header for extracting flash partition information.

Zephyr has switched to using a new gen_defines.py script and a new set of macros/defines for devicetree code generation for all nodes except flash partitions, which are still in the legacy format.

Signed-off-by: Henrik Brix Andersen <henrik@brixandersen.dk>