### PR TITLE
Add Tinycrypt based HKDF

### DIFF
--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -183,6 +183,7 @@ if(CONFIG_BOOT_ENCRYPT_EC256)
     ${TINYCRYPT_DIR}/source/aes_encrypt.c
     ${TINYCRYPT_DIR}/source/aes_decrypt.c
     ${TINYCRYPT_DIR}/source/ctr_mode.c
+    ${TINYCRYPT_DIR}/source/hkdf.c
     ${TINYCRYPT_DIR}/source/hmac.c
     ${TINYCRYPT_DIR}/source/ecc_dh.c
     )

--- a/sim/mcuboot-sys/build.rs
+++ b/sim/mcuboot-sys/build.rs
@@ -210,6 +210,7 @@ fn main() {
         conf.file("../../ext/tinycrypt/lib/source/aes_encrypt.c");
         conf.file("../../ext/tinycrypt/lib/source/aes_decrypt.c");
         conf.file("../../ext/tinycrypt/lib/source/ctr_mode.c");
+        conf.file("../../ext/tinycrypt/lib/source/hkdf.c");
         conf.file("../../ext/tinycrypt/lib/source/hmac.c");
         conf.file("../../ext/tinycrypt/lib/source/ecc_dh.c");
     }


### PR DESCRIPTION
A PR for the existing HKDF in MCUBoot was added here: https://github.com/intel/tinycrypt/pull/43

Once this is merged, this PR should remove the local implementation and switch to using the one provided by Tinycrypt.