### PR TITLE
Add HW key support for image validation

### DIFF
--- a/boot/bootutil/include/bootutil/image.h
+++ b/boot/bootutil/include/bootutil/image.h
@@ -74,6 +74,7 @@ struct flash_area;
  *   2nd one is the actual signature.
  */
 #define IMAGE_TLV_KEYHASH           0x01   /* hash of the public key */
+#define IMAGE_TLV_PUBKEY            0x02   /* public key */
 #define IMAGE_TLV_SHA256            0x10   /* SHA256 of image hdr and body */
 #define IMAGE_TLV_RSA2048_PSS       0x20   /* RSA2048 of hash output */
 #define IMAGE_TLV_ECDSA224          0x21   /* ECDSA of hash output */

--- a/boot/bootutil/include/bootutil/sign_key.h
+++ b/boot/bootutil/include/bootutil/sign_key.h
@@ -20,18 +20,43 @@
 #ifndef __BOOTUTIL_SIGN_KEY_H_
 #define __BOOTUTIL_SIGN_KEY_H_
 
+#include <stddef.h>
 #include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+#ifndef MCUBOOT_HW_KEY
 struct bootutil_key {
     const uint8_t *key;
     const unsigned int *len;
 };
 
 extern const struct bootutil_key bootutil_keys[];
+#else
+struct bootutil_key {
+    uint8_t *key;
+    unsigned int *len;
+};
+
+extern struct bootutil_key bootutil_keys[];
+
+/**
+ * Retrieve the hash of the corresponding public key for image authentication.
+ *
+ * @param[in]      image_index      Index of the image to be authenticated.
+ * @param[out]     public_key_hash  Buffer to store the key-hash in.
+ * @param[in,out]  key_hash_size    As input the size of the buffer. As output
+ *                                  the actual key-hash length.
+ *
+ * @return                          0 on success; nonzero on failure.
+ */
+int boot_retrieve_public_key_hash(uint8_t image_index,
+                                  uint8_t *public_key_hash,
+                                  size_t *key_hash_size);
+#endif /* !MCUBOOT_HW_KEY */
+
 extern const int bootutil_key_cnt;
 
 #ifdef __cplusplus

--- a/boot/cypress/MCUBootApp/keys.c
+++ b/boot/cypress/MCUBootApp/keys.c
@@ -57,6 +57,7 @@
 #include <bootutil/sign_key.h>
 #include <mcuboot_config/mcuboot_config.h>
 
+#if !defined(MCUBOOT_HW_KEY)
 #if defined(MCUBOOT_SIGN_RSA)
 const unsigned char rsa_pub_key[] = {
     0x30, 0x82, 0x01, 0x0a, 0x02, 0x82, 0x01, 0x01, 0x00, 0xd1, 0x06, 0x08,
@@ -163,3 +164,13 @@ const struct bootutil_key bootutil_keys[] = {
 };
 const int bootutil_key_cnt = 1;
 #endif
+#else
+unsigned int pub_key_len;
+struct bootutil_key bootutil_keys[1] = {
+    {
+        .key = 0,
+        .len = &pub_key_len,
+    }
+};
+const int bootutil_key_cnt = 1;
+#endif /* !MCUBOOT_HW_KEY */

--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -1,4 +1,4 @@
-# Copyright (c) 2017 Linaro Limited
+# Copyright (c) 2017-2020 Linaro Limited
 # Copyright (c) 2020 Arm Limited
 #
 # SPDX-License-Identifier: Apache-2.0
@@ -127,6 +127,15 @@ config MCUBOOT_CLEANUP_ARM_CORE
 
 config MBEDTLS_CFG_FILE
 	default "mcuboot-mbedtls-cfg.h"
+
+config BOOT_HW_KEY
+	bool "Use HW key for image verification"
+	default n
+	help
+	  Use HW key for image verification, otherwise the public key is embedded
+	  in MCUBoot. If enabled the public key is appended to the signed image
+	  and requires the hash of the public key to be provisioned to the device
+	  beforehand.
 
 config BOOT_VALIDATE_SLOT0
 	bool "Validate image in the primary slot on every boot"

--- a/boot/zephyr/include/mcuboot_config/mcuboot_config.h
+++ b/boot/zephyr/include/mcuboot_config/mcuboot_config.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2018 Open Source Foundries Limited
  * Copyright (c) 2019-2020 Arm Limited
+ * Copyright (c) 2019-2020 Linaro Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -42,6 +43,10 @@
 #ifdef CONFIG_BOOT_USE_NRF_CC310_BL
 #define MCUBOOT_USE_NRF_CC310_BL
 #endif
+#endif
+
+#ifdef CONFIG_BOOT_HW_KEY
+#define MCUBOOT_HW_KEY
 #endif
 
 #ifdef CONFIG_BOOT_VALIDATE_SLOT0

--- a/boot/zephyr/keys.c
+++ b/boot/zephyr/keys.c
@@ -28,6 +28,7 @@
  */
 #include <mcuboot_config/mcuboot_config.h>
 
+#if !defined(MCUBOOT_HW_KEY)
 #if defined(MCUBOOT_SIGN_RSA)
 #define HAVE_KEYS
 extern const unsigned char rsa_pub_key[];
@@ -65,7 +66,17 @@ const struct bootutil_key bootutil_keys[] = {
     },
 };
 const int bootutil_key_cnt = 1;
-#endif
+#endif /* HAVE_KEYS */
+#else
+unsigned int pub_key_len;
+struct bootutil_key bootutil_keys[1] = {
+    {
+        .key = 0,
+        .len = &pub_key_len,
+    }
+};
+const int bootutil_key_cnt = 1;
+#endif /* !MCUBOOT_HW_KEY */
 
 #if defined(MCUBOOT_ENCRYPT_RSA)
 unsigned char enc_priv_key[] = {

--- a/scripts/imgtool/image.py
+++ b/scripts/imgtool/image.py
@@ -54,6 +54,7 @@ IMAGE_F = {
 
 TLV_VALUES = {
         'KEYHASH': 0x01,
+        'PUBKEY': 0x02,
         'SHA256': 0x10,
         'RSA2048': 0x20,
         'ECDSA224': 0x21,
@@ -259,7 +260,8 @@ class Image():
             format=PublicFormat.UncompressedPoint)
         return cipherkey, ciphermac, pubk
 
-    def create(self, key, enckey, dependencies=None, sw_type=None):
+    def create(self, key, public_key_format, enckey, dependencies=None,
+               sw_type=None):
         self.enckey = enckey
 
         # Calculate the hash of the public key
@@ -360,7 +362,10 @@ class Image():
         tlv.add('SHA256', digest)
 
         if key is not None:
-            tlv.add('KEYHASH', pubbytes)
+            if public_key_format == 'hash':
+                tlv.add('KEYHASH', pubbytes)
+            else:
+                tlv.add('PUBKEY', pub)
 
             # `sign` expects the full image payload (sha256 done internally),
             # while `sign_digest` expects only the digest of the payload

--- a/scripts/imgtool/main.py
+++ b/scripts/imgtool/main.py
@@ -265,14 +265,17 @@ class BasedIntParamType(click.ParamType):
 @click.option('-v', '--version', callback=validate_version,  required=True)
 @click.option('--align', type=click.Choice(['1', '2', '4', '8']),
               required=True)
+@click.option('--public-key-format', type=click.Choice(['hash', 'full']),
+              default='hash', help='In what format to add the public key to '
+              'the image manifest: full key or hash of the key.')
 @click.option('-k', '--key', metavar='filename')
 @click.command(help='''Create a signed or unsigned image\n
                INFILE and OUTFILE are parsed as Intel HEX if the params have
                .hex extension, otherwise binary format is used''')
-def sign(key, align, version, pad_sig, header_size, pad_header, slot_size, pad, confirm,
-         max_sectors, overwrite_only, endian, encrypt, infile, outfile,
-         dependencies, load_addr, hex_addr, erased_val, save_enctlv,
-         security_counter, boot_record):
+def sign(key, public_key_format, align, version, pad_sig, header_size,
+         pad_header, slot_size, pad, confirm, max_sectors, overwrite_only,
+         endian, encrypt, infile, outfile, dependencies, load_addr, hex_addr,
+         erased_val, save_enctlv, security_counter, boot_record):
     img = image.Image(version=decode_version(version), header_size=header_size,
                       pad_header=pad_header, pad=pad, confirm=confirm,
                       align=int(align), slot_size=slot_size,
@@ -295,7 +298,7 @@ def sign(key, align, version, pad_sig, header_size, pad_header, slot_size, pad, 
     if pad_sig and hasattr(key, 'pad_sig'):
         key.pad_sig = True
 
-    img.create(key, enckey, dependencies, boot_record)
+    img.create(key, public_key_format, enckey, dependencies, boot_record)
     img.save(outfile, hex_addr)
 
 


### PR DESCRIPTION
Enable the public key(s) (used for image authentication) to be removed from MCUboot and be appended to the image instead. In this case the key or its hash must be provisioned to the device and MCUboot must be able to retrieve the key-hash from the hardware to compare it with the calculated hash of the public key from the image manifest. After validating the key it can be used for image authentication. This way MCUboot can be independent from the public key(s) (they are not embedded in it).
This feature was already available in TF-M's MCUboot fork, this PR covers its integration with the original MCUboot code. 