### PR TITLE
imgtool: Set RAM_LOAD flag in header when needed

### DIFF
--- a/scripts/imgtool/__init__.py
+++ b/scripts/imgtool/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-imgtool_version = "1.6.0a1"
+imgtool_version = "1.6.0a2"

--- a/scripts/imgtool/image.py
+++ b/scripts/imgtool/image.py
@@ -49,6 +49,7 @@ MAX_SW_TYPE_LENGTH = 12  # Bytes
 IMAGE_F = {
         'PIC':                   0x0000001,
         'NON_BOOTABLE':          0x0000010,
+        'RAM_LOAD':              0x0000020,
         'ENCRYPTED':             0x0000004,
 }
 
@@ -412,6 +413,10 @@ class Image():
         flags = 0
         if enckey is not None:
             flags |= IMAGE_F['ENCRYPTED']
+        if self.load_addr != 0:
+            # Indicates that this image should be loaded into RAM
+            # instead of run directly from flash.
+            flags |= IMAGE_F['RAM_LOAD']
 
         e = STRUCT_ENDIAN_DICT[self.endian]
         fmt = (e +

--- a/scripts/imgtool/main.py
+++ b/scripts/imgtool/main.py
@@ -224,7 +224,7 @@ class BasedIntParamType(click.ParamType):
 @click.option('-x', '--hex-addr', type=BasedIntParamType(), required=False,
               help='Adjust address in hex output file.')
 @click.option('-L', '--load-addr', type=BasedIntParamType(), required=False,
-              help='Load address for image when it is in its primary slot.')
+              help='Load address for image when it should run from RAM.')
 @click.option('--save-enctlv', default=False, is_flag=True,
               help='When upgrading, save encrypted key TLVs instead of plain '
                    'keys. Enable when BOOT_SWAP_SAVE_ENCTLV config option '


### PR DESCRIPTION
Set the RAM_LOAD flag in the image header when a load address was passed
to the imgtool script, indicating that the image should be loaded into
RAM and run from there.