### PR TITLE
imgtool: release 1.6.0alpha3

### DIFF
--- a/scripts/imgtool/__init__.py
+++ b/scripts/imgtool/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-imgtool_version = "1.6.0a2"
+imgtool_version = "1.6.0a3"


### PR DESCRIPTION
Set imgtool version to 1.6.0alpha3 after merging [#712](https://github.com/JuulLabs-OSS/mcuboot/pull/712).