### PR TITLE
Bump imgtool to 1.6.0rc1.post1

### DIFF
--- a/scripts/imgtool/__init__.py
+++ b/scripts/imgtool/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-imgtool_version = "1.6.0rc1"
+imgtool_version = "1.6.0rc1.post1"


### PR DESCRIPTION
Some earlier experiments with auto-pushing to PyPi in travis resulted in
1.6.0rc1 already being uploaded to PyPi.  Create a post1 release from
this to capture the current version.

Signed-off-by: David Brown <david.brown@linaro.org>