### PR TITLE
Fix imgtool publishing missing python package

### DIFF
--- a/ci/imgtool_install.sh
+++ b/ci/imgtool_install.sh
@@ -17,5 +17,5 @@ if [[ $TRAVIS_PULL_REQUEST != "false" || $TRAVIS_BRANCH != "master" ]]; then
     exit 0
 fi
 
-pip3 install setuptools twine
+pip3 install setuptools twine packaging
 pip3 install --pre imgtool


### PR DESCRIPTION
Add missing `packaging` to allow version comparison.