### PR TITLE
Update the simulator docs slightly

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Instructions for different operating systems can be found here:
 - [Zephyr](docs/readme-zephyr.md)
 - [Mynewt](docs/readme-mynewt.md)
 - [RIOT](docs/readme-riot.md)
+- [Simulator](sim/README.rst)
 
 ## Roadmap
 

--- a/sim/README.rst
+++ b/sim/README.rst
@@ -22,7 +22,7 @@ Dependent code
 The simulator depends on some external modules.  These are stored as
 submodules within git.  To fetch these dependencies the first time::
 
-  $ git submodule update --init
+  $ git submodule update --init --recursive
 
 will clone and check out these trees in the appropriate place.
 


### PR DESCRIPTION
Fix the simulator docs to include the `--recursive` argument needed for mbed TLS to now get all of its code. Also, make a link in the top-level docs to the simulator to increase awareness.