### PR TITLE
boot_serial: Initialize possibly initialized variable

### DIFF
--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -583,7 +583,7 @@ boot_serial_start(const struct boot_uart_funcs *f)
 {
     int rc;
     int off;
-    int dec_off;
+    int dec_off = 0;
     int full_line;
     int max_input;
 


### PR DESCRIPTION
The variable `dec_off` can possibly be uninitialized in this function.
As long as the serial protocol used is formed correctly, the
initialization will always happen.  Place an initialization upon
function entry to protect against a case where a malformed protocol is
able to provoke this variable being used before being initialized.

Signed-off-by: David Brown <david.brown@linaro.org>