### PR TITLE
boot: Fix uninitialized variable warning

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -1583,7 +1583,7 @@ context_boot_go(struct boot_loader_state *state, struct boot_rsp *rsp)
 {
     size_t slot;
     struct boot_status bs;
-    int rc;
+    int rc = -1;
     int fa_id;
     int image_index;
     bool has_upgrade;


### PR DESCRIPTION
Tiny patch before release 1.6.0.
Fix uninitialized variable warning that may occur when
compiler optimization is enabled (especially for size).
