### PR TITLE
zephyr/Kconfig: cleanup mcuboot menuconfig

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -376,6 +376,36 @@ config RECOVERY_UART_DEV_NAME
 
 endif # MCUBOOT_SERIAL
 
+config UPDATEABLE_IMAGE_NUMBER
+	int "Number of updateable images"
+	default 1
+	help
+	  Enables support of multi image update.
+
+choice
+	prompt "Downgrade prevention"
+	optional
+
+config MCUBOOT_DOWNGRADE_PREVENTION
+	bool "SW based downgrade prevention"
+	depends on BOOT_UPGRADE_ONLY
+	help
+	  Prevent downgrades by enforcing incrementing version numbers.
+	  When this option is set, any upgrade must have greater major version
+	  or greater minor version with equal major version. This mechanism
+	  only protects against some attacks against version downgrades (for
+	  example, a JTAG could be used to write an older version).
+
+config MCUBOOT_HW_DOWNGRADE_PREVENTION
+	bool "HW based downgrade prevention"
+	help
+	  Prevent undesirable/malicious software downgrades. When this option is
+	  set, any upgrade must have greater or equal security counter value.
+	  Because of the acceptance of equal values it allows for software
+	  downgrade to some extent.
+
+endchoice
+
 endmenu
 
 config MCUBOOT_DEVICE_SETTINGS
@@ -419,35 +449,5 @@ config LOG_PROCESS_THREAD
 # override USB device name
 config USB_DEVICE_PRODUCT
 	default "MCUBOOT"
-
-config UPDATEABLE_IMAGE_NUMBER
-	int "Number of updateable images"
-	default 1
-	help
-	  Enables support of multi image update.
-
-choice
-	prompt "Downgrade prevention"
-	optional
-
-config MCUBOOT_DOWNGRADE_PREVENTION
-	bool "SW based downgrade prevention"
-	depends on BOOT_UPGRADE_ONLY
-	help
-	  Prevent downgrades by enforcing incrementing version numbers.
-	  When this option is set, any upgrade must have greater major version
-	  or greater minor version with equal major version. This mechanism
-	  only protects against some attacks against version downgrades (for
-	  example, a JTAG could be used to write an older version).
-
-config MCUBOOT_HW_DOWNGRADE_PREVENTION
-	bool "HW based downgrade prevention"
-	help
-	  Prevent undesirable/malicious software downgrades. When this option is
-	  set, any upgrade must have greater or equal security counter value.
-	  Because of the acceptance of equal values it allows for software
-	  downgrade to some extent.
-
-endchoice
 
 source "Kconfig.zephyr"


### PR DESCRIPTION
A few mcuboot option were outside of mcuboot-specific
menu.
This patch moves them into mcuboot menu.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>