### PR TITLE
cmake: scripts: now using ZEPHYR_BASE as local variable

### DIFF
--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -62,7 +62,7 @@ assert_exists(MBEDTLS_ASN1_DIR)
 set(NRF_DIR "${MCUBOOT_DIR}/ext/nrf")
 
 if(CONFIG_BOOT_USE_NRF_CC310_BL)
-set(NRFXLIB_DIR $ENV{ZEPHYR_BASE}/../nrfxlib)
+set(NRFXLIB_DIR ${ZEPHYR_BASE}/../nrfxlib)
 assert_exists(NRFXLIB_DIR)
 # Don't include this if we are using west
  add_subdirectory(${NRFXLIB_DIR} ${PROJECT_BINARY_DIR}/nrfxlib)

--- a/samples/zephyr/Makefile
+++ b/samples/zephyr/Makefile
@@ -92,6 +92,7 @@ all: boot hello1 hello2
 
 full.bin: boot hello1 hello2
 	$(ASSEMBLE) -b $(BUILD_DIR_BOOT) \
+	    -z $(ZEPHYR_BASE) \
 	    -p signed-hello1.bin \
 	    -s signed-hello2.bin \
 	    -o full.bin

--- a/samples/zephyr/hello-world/CMakeLists.txt
+++ b/samples/zephyr/hello-world/CMakeLists.txt
@@ -11,8 +11,9 @@
 
 cmake_minimum_required(VERSION 3.8)
 
-# Standard Zephyr application boilerplate.
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+# find_package(Zephyr) in order to load application boilerplate:
+# http://docs.zephyrproject.org/application/application.html
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 # This string ends up getting printed in the device console

--- a/scripts/assemble.py
+++ b/scripts/assemble.py
@@ -25,13 +25,6 @@ import re
 import os.path
 import sys
 
-ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
-if not ZEPHYR_BASE:
-    sys.exit("$ZEPHYR_BASE environment variable undefined")
-
-sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts", "dts"))
-import edtlib
-
 def same_keys(a, b):
     """Determine if the dicts a and b have the same keys in them"""
     for ak in a.keys():
@@ -109,15 +102,20 @@ def main():
             help='Signed image file for secondary image')
     parser.add_argument('-o', '--output', required=True,
             help='Filename to write full image to')
+    parser.add_argument('-z', '--zephyr-base', required=True,
+            help='Zephyr base containg the Zephyr repository')
 
     args = parser.parse_args()
+
+    sys.path.insert(0, os.path.join(args.zephyr_base, "scripts", "dts"))
+    import edtlib
 
     # Extract board name from path
     board = os.path.split(os.path.split(args.bootdir)[0])[1]
 
     dts_path = os.path.join(args.bootdir, "zephyr", board + ".dts.pre.tmp")
 
-    edt = edtlib.EDT(dts_path, [os.path.join(ZEPHYR_BASE, "dts", "bindings")],
+    edt = edtlib.EDT(dts_path, [os.path.join(args.zephyr_base, "dts", "bindings")],
             warn_reg_unit_address_mismatch=False)
 
     output = Assembly(args.output, args.bootdir, edt)


### PR DESCRIPTION
This commit is a followup to the usage of `find_package(Zephyr ...)`.

The zephyr/hello-world sample has been updated to use find_package.
The assemble.py script now takes ZEPHYR_BASE as an argument, so it may
be used from CMakeLists.txt files when ZEPHYR_BASE is not set in
environment, and thus the Makefile sample has been adjusted accordingly.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>