### PR TITLE
zephyr: fix zephyr testcase extra_tags

### DIFF
--- a/boot/zephyr/sample.yaml
+++ b/boot/zephyr/sample.yaml
@@ -15,6 +15,6 @@ tests:
     platform_whitelist:  nrf52840dongle_nrf52840
   sample.bootloader.mcuboot.usb_cdc_acm_recovery_log:
     extra_args: OVERLAY_CONFIG=./usb_cdc_acm_log_recovery.conf
-      DTC_OVERLAY=./boards/nrf52840_big.overlay
+      DTC_OVERLAY_FILE=./boards/nrf52840_big.overlay
     platform_whitelist:  nrf52840dk_nrf52840
     tags: bootloader_mcuboot


### PR DESCRIPTION
dtc overlay should be transfered via DTC_OVERLAY_FILE,
not by DTC_OVERLAY.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>