### PR TITLE
Allow larger primary slot in swap-move

### DIFF
--- a/scripts/imgtool/main.py
+++ b/scripts/imgtool/main.py
@@ -260,7 +260,8 @@ class BasedIntParamType(click.ParamType):
 @click.option('--pad', default=False, is_flag=True,
               help='Pad image to --slot-size bytes, adding trailer magic')
 @click.option('-S', '--slot-size', type=BasedIntParamType(), required=True,
-              help='Size of the slot where the image will be written')
+              help='Size of the slot. If the slots have different sizes, use '
+              'the size of the secondary slot.')
 @click.option('--pad-header', default=False, is_flag=True,
               help='Add --header-size zeroed bytes at the beginning of the '
                    'image')

--- a/sim/src/image.rs
+++ b/sim/src/image.rs
@@ -325,6 +325,19 @@ impl ImagesBuilder {
                 flash.insert(dev_id, dev);
                 (flash, areadesc, &[])
             }
+            DeviceName::Nrf52840UnequalSlots => {
+                let dev = SimFlash::new(vec![4096; 128], align as usize, erased_val);
+
+                let dev_id = 0;
+                let mut areadesc = AreaDesc::new();
+                areadesc.add_flash_sectors(dev_id, &dev);
+                areadesc.add_image(0x008000, 0x03c000, FlashId::Image0, dev_id);
+                areadesc.add_image(0x044000, 0x03b000, FlashId::Image1, dev_id);
+
+                let mut flash = SimMultiFlash::new();
+                flash.insert(dev_id, dev);
+                (flash, areadesc, &[Caps::SwapUsingScratch, Caps::OverwriteUpgrade])
+            }
             DeviceName::Nrf52840SpiFlash => {
                 // Simulate nrf52840 with external SPI flash. The external SPI flash
                 // has a larger sector size so for now store scratch on that flash.

--- a/sim/src/lib.rs
+++ b/sim/src/lib.rs
@@ -62,7 +62,10 @@ struct Args {
 }
 
 #[derive(Copy, Clone, Debug, Deserialize)]
-pub enum DeviceName { Stm32f4, K64f, K64fBig, K64fMulti, Nrf52840, Nrf52840SpiFlash, }
+pub enum DeviceName {
+    Stm32f4, K64f, K64fBig, K64fMulti, Nrf52840, Nrf52840SpiFlash,
+    Nrf52840UnequalSlots,
+}
 
 pub static ALL_DEVICES: &'static [DeviceName] = &[
     DeviceName::Stm32f4,
@@ -71,6 +74,7 @@ pub static ALL_DEVICES: &'static [DeviceName] = &[
     DeviceName::K64fMulti,
     DeviceName::Nrf52840,
     DeviceName::Nrf52840SpiFlash,
+    DeviceName::Nrf52840UnequalSlots,
 ];
 
 impl fmt::Display for DeviceName {
@@ -82,6 +86,7 @@ impl fmt::Display for DeviceName {
             DeviceName::K64fMulti => "k64fmulti",
             DeviceName::Nrf52840 => "nrf52840",
             DeviceName::Nrf52840SpiFlash => "Nrf52840SpiFlash",
+            DeviceName::Nrf52840UnequalSlots => "Nrf52840UnequalSlots",
         };
         f.write_str(name)
     }


### PR DESCRIPTION
When using swap in move mode, the current compatibility test only allows for same size and layout between slots. This results in one sector that can never be used in the secondary slot, which corresponds to the first move up operation in the primary slot. This relaxes and checking a bit, so both same size slots and a primary with one extra sector are valid.