### PR TITLE
Fix erase of possible trailer leftover after reset

### DIFF
--- a/sim/tests/core.rs
+++ b/sim/tests/core.rs
@@ -47,6 +47,7 @@ macro_rules! sim_test {
 }
 
 sim_test!(bad_secondary_slot, make_bad_secondary_slot_image(), run_signfail_upgrade());
+sim_test!(secondary_trailer_leftover, make_erased_secondary_image(), run_secondary_leftover_trailer());
 sim_test!(norevert_newimage, make_no_upgrade_image(&NO_DEPS), run_norevert_newimage());
 sim_test!(basic_revert, make_image(&NO_DEPS, true), run_basic_revert());
 sim_test!(revert_with_fails, make_image(&NO_DEPS, false), run_revert_with_fails());


### PR DESCRIPTION
This fixes an issue where an image might be erased, but a trailer left behind. It can happen if the image in the secondary slot did not pass validation, in which case the whole slot is erased. If during the erase operation, a reset occurs, parts of the slot might have been erased while some have not. The concerning part is the trailer because it might disable a new image from being loaded through mcumgr; so just get rid of the trailer here, if the header is erased.