### PR TITLE
zephyr: serial: Align with new callback signature

### DIFF
--- a/boot/zephyr/serial_adapter.c
+++ b/boot/zephyr/serial_adapter.c
@@ -115,7 +115,7 @@ boot_console_init(void)
 }
 
 static void
-boot_uart_fifo_callback(struct device *dev)
+boot_uart_fifo_callback(struct device *dev, void *user_data)
 {
 	static struct line_input *cmd;
 	uint8_t byte;


### PR DESCRIPTION
Align the code to the new UART callback signature, see:

https://github.com/zephyrproject-rtos/zephyr/pull/26426

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>