### PR TITLE
SW counter measures against HW level fault injection

### DIFF
--- a/boot/bootutil/include/bootutil/bootutil.h
+++ b/boot/bootutil/include/bootutil/bootutil.h
@@ -3,7 +3,7 @@
  *
  * Copyright (c) 2017-2019 Linaro LTD
  * Copyright (c) 2016-2019 JUUL Labs
- * Copyright (c) 2019 Arm Limited
+ * Copyright (c) 2019-2020 Arm Limited
  *
  * Original license:
  *
@@ -29,6 +29,7 @@
 #define H_BOOTUTIL_
 
 #include <inttypes.h>
+#include "bootutil/fault_injection_hardening.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -91,10 +92,10 @@ struct image_trailer {
 };
 
 /* you must have pre-allocated all the entries within this structure */
-int boot_go(struct boot_rsp *rsp);
+fih_int boot_go(struct boot_rsp *rsp);
 
 struct boot_loader_state;
-int context_boot_go(struct boot_loader_state *state, struct boot_rsp *rsp);
+fih_int context_boot_go(struct boot_loader_state *state, struct boot_rsp *rsp);
 
 int boot_swap_type_multi(int image_index);
 int boot_swap_type(void);
@@ -105,8 +106,8 @@ int boot_set_confirmed(void);
 #define SPLIT_GO_OK                 (0)
 #define SPLIT_GO_NON_MATCHING       (-1)
 #define SPLIT_GO_ERR                (-2)
-int
-split_go(int loader_slot, int split_slot, void **entry);
+
+fih_int split_go(int loader_slot, int split_slot, void **entry);
 
 #ifdef __cplusplus
 }

--- a/boot/bootutil/include/bootutil/fault_injection_hardening.h
+++ b/boot/bootutil/include/bootutil/fault_injection_hardening.h
@@ -1,0 +1,356 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2020 Arm Limited
+ */
+
+#ifndef __FAULT_INJECTION_HARDENING_H__
+#define __FAULT_INJECTION_HARDENING_H__
+
+/* Fault injection mitigation library.
+ *
+ * Has support for different measures, which can either be enabled/disabled
+ * separately or by defining one of the MCUBOOT_FIH_PROFILEs.
+ *
+ * NOTE: These constructs against fault injection attacks are not guaranteed to
+ *       be secure for all compilers, but execution is going to be correct and
+ *       including them will certainly help to harden the code.
+ *
+ * FIH_ENABLE_DOUBLE_VARS makes critical variables into a tuple (x, x ^ msk).
+ * Then the correctness of x can be checked by XORing the two tuple values
+ * together. This also means that comparisons between fih_ints can be verified
+ * by doing x == y && x_msk == y_msk.
+ *
+ * FIH_ENABLE_GLOBAL_FAIL makes all while(1) failure loops redirect to a global
+ * failure loop. This loop has mitigations against loop escapes / unlooping.
+ * This also means that any unlooping won't immediately continue executing the
+ * function that was executing before the failure.
+ *
+ * FIH_ENABLE_CFI (Control Flow Integrity) creates a global counter that is
+ * incremented before every FIH_CALL of vulnerable functions. On the function
+ * return the counter is decremented, and after the return it is verified that
+ * the counter has the same value as before this process. This can be used to
+ * verify that the function has actually been called. This protection is
+ * intended to discover that important functions are called in an expected
+ * sequence and neither of them is missed due to an instruction skip which could
+ * be a result of glitching attack. It does not provide protection against ROP
+ * or JOP attacks.
+ *
+ * FIH_ENABLE_DELAY causes random delays. This makes it hard to cause faults
+ * precisely. It requires an RNG. An mbedtls integration is provided in
+ * fault_injection_hardening_delay_mbedtls.h, but any RNG that has an entropy
+ * source can be used by implementing the fih_delay_random_uchar function.
+ *
+ * The basic call pattern is:
+ *
+ * fih_int fih_rc = FIH_FAILURE;
+ * FIH_CALL(vulnerable_function, fih_rc, arg1, arg2);
+ * if (fih_not_eq(fih_rc, FIH_SUCCESS)) {
+ *     FIH_PANIC;
+ * }
+ *
+ * Note that any function called by FIH_CALL must only return using FIH_RETURN,
+ * as otherwise the CFI counter will not be decremented and the CFI check will
+ * fail causing a panic.
+ */
+
+#include "mcuboot_config/mcuboot_config.h"
+
+#if defined(MCUBOOT_FIH_PROFILE_HIGH)
+
+#define FIH_ENABLE_DELAY         /* Requires an entropy source */
+#define FIH_ENABLE_DOUBLE_VARS
+#define FIH_ENABLE_GLOBAL_FAIL
+#define FIH_ENABLE_CFI
+
+#elif defined(MCUBOOT_FIH_PROFILE_MEDIUM)
+
+#define FIH_ENABLE_DOUBLE_VARS
+#define FIH_ENABLE_GLOBAL_FAIL
+#define FIH_ENABLE_CFI
+
+#elif defined(MCUBOOT_FIH_PROFILE_LOW)
+
+#define FIH_ENABLE_GLOBAL_FAIL
+#define FIH_ENABLE_CFI
+
+#else
+#define MCUBOOT_FIH_PROFILE_OFF
+#endif /* MCUBOOT_FIH_PROFILE */
+
+#ifdef FIH_ENABLE_DELAY
+#include "fault_injection_hardening_delay_rng.h"
+#endif /* FIH_ENABLE_DELAY */
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/* Non-zero success value to defend against register resets. Zero is the most
+ * common value for a corrupted register so complex bit-patterns are used
+ */
+#ifndef MCUBOOT_FIH_PROFILE_OFF
+#define FIH_POSITIVE_VALUE 0x1AAAAAAA
+#define FIH_NEGATIVE_VALUE 0x15555555
+#else
+#define FIH_POSITIVE_VALUE 0
+#define FIH_NEGATIVE_VALUE -1
+#endif
+
+/* A volatile mask is used to prevent compiler optimization - the mask is xored
+ * with the variable to create the backup and the integrity can be checked with
+ * another xor. The mask value doesn't _really_ matter that much, as long as
+ * it has reasonably high hamming weight.
+ */
+#define _FIH_MASK_VALUE 0xBEEF
+
+#ifdef FIH_ENABLE_DOUBLE_VARS
+
+/* All ints are replaced with two int - the normal one and a backup which is
+ * XORed with the mask.
+ */
+extern volatile int _fih_mask;
+typedef volatile struct {
+    volatile int val;
+    volatile int msk;
+} fih_int;
+
+#else
+
+typedef int fih_int;
+
+#endif /* FIH_ENABLE_DOUBLE_VARS */
+
+extern fih_int FIH_SUCCESS;
+extern fih_int FIH_FAILURE;
+
+#ifdef FIH_ENABLE_GLOBAL_FAIL
+/* Global failure handler - more resistant to unlooping. noinline and used are
+ * used to prevent optimization
+ */
+__attribute__((noinline)) __attribute__((used))
+void fih_panic_loop(void);
+#define FIH_PANIC fih_panic_loop()
+#else
+#define FIH_PANIC while (1) {}
+#endif  /* FIH_ENABLE_GLOBAL_FAIL */
+
+/* NOTE: For functions to be inlined outside their compilation unit they have to
+ * have the body in the header file. This is required as function calls are easy
+ * to skip.
+ */
+#ifdef FIH_ENABLE_DELAY
+#include "bootutil/bootutil_log.h"
+
+/* Delaying logic, with randomness from a CSPRNG */
+__attribute__((always_inline)) inline
+int fih_delay(void)
+{
+    unsigned char delay;
+    int foo = 0;
+    volatile int rc;
+
+    delay = fih_delay_random_uchar();
+
+    for (volatile int i = 0; i < delay; i++) {
+        foo++;
+    }
+
+    rc = 1;
+
+    /* rc is volatile so if it is the return value then the function cannot be
+     * optimized
+     */
+    return rc;
+}
+
+#else
+
+__attribute__((always_inline)) inline
+int fih_delay_init(void)
+{
+    return 1;
+}
+
+__attribute__((always_inline)) inline
+int fih_delay(void)
+{
+    return 1;
+}
+#endif /* FIH_ENABLE_DELAY */
+
+#ifdef FIH_ENABLE_DOUBLE_VARS
+
+__attribute__((always_inline)) inline
+void fih_int_validate(fih_int x)
+{
+    if (x.val != (x.msk ^ _fih_mask)) {
+        FIH_PANIC;
+    }
+}
+
+/* Convert a fih_int to an int. Validate for tampering. */
+__attribute__((always_inline)) inline
+int fih_int_decode(fih_int x)
+{
+    fih_int_validate(x);
+    return x.val;
+}
+
+/* Convert an int to a fih_int, can be used to encode specific error codes. */
+__attribute__((always_inline)) inline
+fih_int fih_int_encode(int x)
+{
+    fih_int ret = {x, x ^ _fih_mask};
+    return ret;
+}
+
+/* Standard equality. If A == B then 1, else 0 */
+__attribute__((always_inline)) inline
+int fih_eq(fih_int x, fih_int y)
+{
+    fih_int_validate(x);
+    fih_int_validate(y);
+    return (x.val == y.val) && fih_delay() && (x.msk == y.msk);
+}
+
+__attribute__((always_inline)) inline
+int fih_not_eq(fih_int x, fih_int y)
+{
+    fih_int_validate(x);
+    fih_int_validate(y);
+    return (x.val != y.val) && fih_delay() && (x.msk != y.msk);
+}
+
+#else
+
+/* NOOP */
+__attribute__((always_inline)) inline
+void fih_int_validate(fih_int x)
+{
+    (void) x;
+    return;
+}
+
+/* NOOP */
+__attribute__((always_inline)) inline
+int fih_int_decode(fih_int x)
+{
+    return x;
+}
+
+/* NOOP */
+__attribute__((always_inline)) inline
+fih_int fih_int_encode(int x)
+{
+    return x;
+}
+
+__attribute__((always_inline)) inline
+int fih_eq(fih_int x, fih_int y)
+{
+    return x == y;
+}
+
+__attribute__((always_inline)) inline
+int fih_not_eq(fih_int x, fih_int y)
+{
+    return x != y;
+}
+#endif /* FIH_ENABLE_DOUBLE_VARS */
+
+/* C has a common return pattern where 0 is a correct value and all others are
+ * errors. This function converts 0 to FIH_SUCCESS and any other number to a
+ * value that is not FIH_SUCCESS
+ */
+__attribute__((always_inline)) inline
+fih_int fih_int_encode_zero_equality(int x)
+{
+    if (x) {
+        return FIH_FAILURE;
+    } else {
+        return FIH_SUCCESS;
+    }
+}
+
+#ifdef FIH_ENABLE_CFI
+extern fih_int _fih_cfi_ctr;
+#endif /* FIH_ENABLE_CFI */
+
+fih_int fih_cfi_get_and_increment(void);
+void fih_cfi_validate(fih_int saved);
+void fih_cfi_decrement(void);
+
+/* Label for interacting with FIH testing tool. Can be parsed from the elf file
+ * after compilation. Does not require debug symbols.
+ */
+#define FIH_LABEL(str) __asm volatile ("FIH_LABEL_" str "_%=:" ::);
+
+/* Main FIH calling macro. return variable is second argument. Does some setup
+ * before and validation afterwards. Inserts labels for use with testing script.
+ *
+ * First perform the precall step - this gets the current value of the CFI
+ * counter and saves it to a local variable, and then increments the counter.
+ *
+ * Then set the return variable to FIH_FAILURE as a base case.
+ *
+ * Then perform the function call. As part of the funtion FIH_RET must be called
+ * which will decrement the counter.
+ *
+ * The postcall step gets the value of the counter and compares it to the
+ * previously saved value. If this is equal then the function call and all child
+ * function calls were performed.
+ */
+#define FIH_CALL(f, ret, ...) \
+    do { \
+        FIH_LABEL("FIH_CALL_START"); \
+        FIH_CFI_PRECALL_BLOCK; \
+        ret = FIH_FAILURE; \
+        if (fih_delay()) { \
+            ret = f(__VA_ARGS__); \
+        } \
+        FIH_CFI_POSTCALL_BLOCK; \
+        FIH_LABEL("FIH_CALL_END"); \
+    } while (0)
+
+/* FIH return changes the state of the internal state machine. If you do a
+ * FIH_CALL then you need to do a FIH_RET else the state machine will detect
+ * tampering and panic.
+ */
+#define FIH_RET(ret) \
+    do { \
+        FIH_CFI_PRERET; \
+        return ret; \
+    } while (0)
+
+
+#ifdef FIH_ENABLE_CFI
+/* Macro wrappers for functions - Even when the functions have zero body this
+ * saves a few bytes on noop functions as it doesn't generate the call/ret
+ *
+ * CFI precall function saves the CFI counter and then increments it - the
+ * postcall then checks if the counter is equal to the saved value. In order for
+ * this to be the case a FIH_RET must have been performed inside the called
+ * function in order to decrement the counter, so the function must have been
+ * called.
+ */
+#define FIH_CFI_PRECALL_BLOCK \
+    fih_int _fih_cfi_saved_value = fih_cfi_get_and_increment()
+
+#define FIH_CFI_POSTCALL_BLOCK \
+        fih_cfi_validate(_fih_cfi_saved_value)
+
+#define FIH_CFI_PRERET \
+        fih_cfi_decrement()
+#else
+#define FIH_CFI_PRECALL_BLOCK
+#define FIH_CFI_POSTCALL_BLOCK
+#define FIH_CFI_PRERET
+#endif  /* FIH_ENABLE_CFI */
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* __FAULT_INJECTION_HARDENING_H__ */

--- a/boot/bootutil/include/bootutil/fault_injection_hardening_delay_rng.h
+++ b/boot/bootutil/include/bootutil/fault_injection_hardening_delay_rng.h
@@ -1,0 +1,30 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2020 Arm Limited
+ */
+
+#ifndef __FAULT_INJECTION_HARDENING_DELAY_RNG_H__
+#define __FAULT_INJECTION_HARDENING_DELAY_RNG_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/**
+ * \brief Set up the RNG for use with random delays. Called once at startup.
+ */
+int fih_delay_init(void);
+
+/**
+ * \brief Get a random unsigned char from an RNG seeded with an entropy source.
+ *
+ * \return A random value that fits inside an unsigned char.
+ */
+unsigned char fih_delay_random_uchar(void);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* __FAULT_INJECTION_HARDENING_DELAY_RNG_H__ */

--- a/boot/bootutil/include/bootutil/image.h
+++ b/boot/bootutil/include/bootutil/image.h
@@ -30,6 +30,7 @@
 
 #include <inttypes.h>
 #include <stdbool.h>
+#include "bootutil/fault_injection_hardening.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -139,11 +140,11 @@ _Static_assert(sizeof(struct image_header) == IMAGE_HEADER_SIZE,
                "struct image_header not required size");
 
 struct enc_key_data;
-int bootutil_img_validate(struct enc_key_data *enc_state, int image_index,
-                          struct image_header *hdr,
-                          const struct flash_area *fap,
-                          uint8_t *tmp_buf, uint32_t tmp_buf_sz,
-                          uint8_t *seed, int seed_len, uint8_t *out_hash);
+fih_int bootutil_img_validate(struct enc_key_data *enc_state, int image_index,
+                              struct image_header *hdr,
+                              const struct flash_area *fap,
+                              uint8_t *tmp_buf, uint32_t tmp_buf_sz,
+                              uint8_t *seed, int seed_len, uint8_t *out_hash);
 
 struct image_tlv_iter {
     const struct image_header *hdr;

--- a/boot/bootutil/include/bootutil/security_cnt.h
+++ b/boot/bootutil/include/bootutil/security_cnt.h
@@ -26,6 +26,7 @@
  */
 
 #include <stdint.h>
+#include "bootutil/fault_injection_hardening.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -34,9 +35,9 @@ extern "C" {
 /**
  * Initialises the security counters.
  *
- * @return                  0 on success; nonzero on failure.
+ * @return                  FIH_SUCCESS on success
  */
-int32_t boot_nv_security_counter_init(void);
+fih_int boot_nv_security_counter_init(void);
 
 /**
  * Reads the stored value of a given image's security counter.
@@ -44,9 +45,9 @@ int32_t boot_nv_security_counter_init(void);
  * @param image_id          Index of the image (from 0).
  * @param security_cnt      Pointer to store the security counter value.
  *
- * @return                  0 on success; nonzero on failure.
+ * @return                  FIH_SUCCESS on success
  */
-int32_t boot_nv_security_counter_get(uint32_t image_id, uint32_t *security_cnt);
+fih_int boot_nv_security_counter_get(uint32_t image_id, fih_int *security_cnt);
 
 /**
  * Updates the stored value of a given image's security counter with a new

--- a/boot/bootutil/src/bootutil_misc.c
+++ b/boot/bootutil/src/bootutil_misc.c
@@ -3,7 +3,7 @@
  *
  * Copyright (c) 2017-2019 Linaro LTD
  * Copyright (c) 2016-2019 JUUL Labs
- * Copyright (c) 2019 Arm Limited
+ * Copyright (c) 2019-2020 Arm Limited
  *
  * Original license:
  *
@@ -36,6 +36,7 @@
 #include "bootutil/bootutil.h"
 #include "bootutil_priv.h"
 #include "bootutil/bootutil_log.h"
+#include "bootutil/fault_injection_hardening.h"
 #ifdef MCUBOOT_ENC_IMAGES
 #include "bootutil/enc_key.h"
 #endif
@@ -105,6 +106,49 @@ static const struct boot_swap_table boot_swap_tables[] = {
 
 #define BOOT_SWAP_TABLES_COUNT \
     (sizeof boot_swap_tables / sizeof boot_swap_tables[0])
+
+/**
+ * @brief Determine if the data at two memory addresses is equal
+ *
+ * @param s1    The first  memory region to compare.
+ * @param s2    The second memory region to compare.
+ * @param n     The amount of bytes to compare.
+ *
+ * @note        This function does not comply with the specification of memcmp,
+ *              so should not be considered a drop-in replacement. It has no
+ *              constant time execution. The point is to make sure that all the
+ *              bytes are compared and detect if loop was abused and some cycles
+ *              was skipped due to fault injection.
+ *
+ * @return      FIH_SUCCESS if memory regions are equal, otherwise FIH_FAILURE
+ */
+#ifdef MCUBOOT_FIH_PROFILE_OFF
+inline
+fih_int boot_fih_memequal(const void *s1, const void *s2, size_t n)
+{
+    return memcmp(s1, s2, n);
+}
+#else
+fih_int boot_fih_memequal(const void *s1, const void *s2, size_t n)
+{
+    size_t i;
+    uint8_t *s1_p = (uint8_t*) s1;
+    uint8_t *s2_p = (uint8_t*) s2;
+    fih_int ret = FIH_FAILURE;
+
+    for (i = 0; i < n; i++) {
+        if (s1_p[i] != s2_p[i]) {
+            goto out;
+        }
+    }
+    if (i == n) {
+        ret = FIH_SUCCESS;
+    }
+
+out:
+    FIH_RET(ret);
+}
+#endif
 
 static int
 boot_magic_decode(const uint32_t *magic)

--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -36,6 +36,7 @@
 
 #include "bootutil/bootutil.h"
 #include "bootutil/image.h"
+#include "bootutil/fault_injection_hardening.h"
 #include "mcuboot_config/mcuboot_config.h"
 
 #ifdef MCUBOOT_ENC_IMAGES
@@ -284,8 +285,10 @@ struct boot_loader_state {
 #endif
 };
 
-int bootutil_verify_sig(uint8_t *hash, uint32_t hlen, uint8_t *sig,
-                        size_t slen, uint8_t key_id);
+fih_int bootutil_verify_sig(uint8_t *hash, uint32_t hlen, uint8_t *sig,
+                            size_t slen, uint8_t key_id);
+
+fih_int boot_fih_memequal(const void *s1, const void *s2, size_t n);
 
 int boot_magic_compatible_check(uint8_t tbl_val, uint8_t val);
 uint32_t boot_status_sz(uint32_t min_write_sz);

--- a/boot/bootutil/src/fault_injection_hardening.c
+++ b/boot/bootutil/src/fault_injection_hardening.c
@@ -1,0 +1,78 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2020 Arm Limited
+ */
+
+#include "bootutil/fault_injection_hardening.h"
+
+#ifdef FIH_ENABLE_DOUBLE_VARS
+/* Variable that could be (but isn't) changed at runtime to force the compiler
+ * not to optimize the double check. Value doesn't matter.
+ */
+volatile int _fih_mask = _FIH_MASK_VALUE;
+fih_int FIH_SUCCESS = {FIH_POSITIVE_VALUE, _FIH_MASK_VALUE ^ FIH_POSITIVE_VALUE};
+fih_int FIH_FAILURE = {FIH_NEGATIVE_VALUE, _FIH_MASK_VALUE ^ FIH_NEGATIVE_VALUE};
+#else
+fih_int FIH_SUCCESS = {FIH_POSITIVE_VALUE};
+fih_int FIH_FAILURE = {FIH_NEGATIVE_VALUE};
+#endif /* FIH_ENABLE_DOUBLE_VARS */
+
+#ifdef FIH_ENABLE_CFI
+
+#ifdef FIH_ENABLE_DOUBLE_VARS
+fih_int _fih_cfi_ctr = {0, 0 ^ _FIH_MASK_VALUE};
+#else
+fih_int _fih_cfi_ctr = {0};
+#endif /* FIH_ENABLE_DOUBLE_VARS */
+
+/* Increment the CFI counter by one, and return the value before the increment.
+ */
+fih_int fih_cfi_get_and_increment(void)
+{
+    fih_int saved = _fih_cfi_ctr;
+    _fih_cfi_ctr = fih_int_encode(fih_int_decode(saved) + 1);
+    return saved;
+}
+
+/* Validate that the saved precall value is the same as the value of the global
+ * counter. For this to be the case, a fih_ret must have been called between
+ * these functions being executed. If the values aren't the same then panic.
+ */
+void fih_cfi_validate(fih_int saved)
+{
+    if (fih_int_decode(saved) != fih_int_decode(_fih_cfi_ctr)) {
+        FIH_PANIC;
+    }
+}
+
+/* Decrement the global CFI counter by one, so that it has the same value as
+ * before the cfi_precall
+ */
+void fih_cfi_decrement(void)
+{
+    _fih_cfi_ctr = fih_int_encode(fih_int_decode(_fih_cfi_ctr) - 1);
+}
+
+#endif /* FIH_ENABLE_CFI */
+
+#ifdef FIH_ENABLE_GLOBAL_FAIL
+/* Global failure loop for bootloader code. Uses attribute used to prevent
+ * compiler removing due to non-standard calling procedure. Multiple loop jumps
+ * used to make unlooping difficult.
+ */
+__attribute__((used))
+__attribute__((noinline))
+void fih_panic_loop(void)
+{
+    __asm volatile ("b fih_panic_loop");
+    __asm volatile ("b fih_panic_loop");
+    __asm volatile ("b fih_panic_loop");
+    __asm volatile ("b fih_panic_loop");
+    __asm volatile ("b fih_panic_loop");
+    __asm volatile ("b fih_panic_loop");
+    __asm volatile ("b fih_panic_loop");
+    __asm volatile ("b fih_panic_loop");
+    __asm volatile ("b fih_panic_loop");
+}
+#endif /* FIH_ENABLE_GLOBAL_FAIL */

--- a/boot/bootutil/src/fault_injection_hardening_delay_rng_mbedtls.c
+++ b/boot/bootutil/src/fault_injection_hardening_delay_rng_mbedtls.c
@@ -1,0 +1,51 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2020 Arm Limited
+ */
+
+#include "bootutil/fault_injection_hardening.h"
+
+#ifdef FIH_ENABLE_DELAY
+
+#include "bootutil/fault_injection_hardening_delay_rng.h"
+#include "mcuboot-mbedtls-cfg.h"
+#include "mbedtls/ctr_drbg.h"
+#include "mbedtls/entropy.h"
+
+#include "bootutil/bootutil_log.h"
+
+/* Mbedtls implementation of the delay RNG. Can be replaced by any other RNG
+ * implementation that is backed by an entropy source by altering these
+ * functions. This is not provided as a header API and a C file implementation
+ * due to issues with inlining.
+ */
+
+#ifdef MBEDTLS_NO_DEFAULT_ENTROPY_SOURCES
+#error "FIH_ENABLE_DELAY requires an entropy source"
+#endif /* MBEDTLS_NO_DEFAULT_ENTROPY_SOURCES */
+
+mbedtls_entropy_context fih_entropy_ctx;
+mbedtls_ctr_drbg_context fih_drbg_ctx;
+
+int fih_delay_init(void)
+{
+    mbedtls_entropy_init(&fih_entropy_ctx);
+    mbedtls_ctr_drbg_init(&fih_drbg_ctx);
+    mbedtls_ctr_drbg_seed(&fih_drbg_ctx , mbedtls_entropy_func,
+                          &fih_entropy_ctx, NULL, 0);
+
+    return 1;
+}
+
+unsigned char fih_delay_random_uchar(void)
+{
+    unsigned char delay;
+
+    mbedtls_ctr_drbg_random(&fih_drbg_ctx,(unsigned char*) &delay,
+                            sizeof(delay));
+
+    return delay;
+}
+
+#endif /* FIH_ENABLE_DELAY */

--- a/boot/bootutil/src/image_rsa.c
+++ b/boot/bootutil/src/image_rsa.c
@@ -3,6 +3,7 @@
  *
  * Copyright (c) 2017-2018 Linaro LTD
  * Copyright (c) 2017-2019 JUUL Labs
+ * Copyright (c) 2020 Arm Limited
  *
  * Original license:
  *
@@ -37,6 +38,7 @@
 #include "mbedtls/version.h"
 
 #include "bootutil_priv.h"
+#include "bootutil/fault_injection_hardening.h"
 
 /*
  * Constants for this particular constrained implementation of
@@ -157,7 +159,7 @@ pss_mgf1(uint8_t *mask, const uint8_t *hash)
  * v2.2, section 9.1.2, with many parameters required to have fixed
  * values.
  */
-static int
+static fih_int
 bootutil_cmp_rsasig(mbedtls_rsa_context *ctx, uint8_t *hash, uint32_t hlen,
   uint8_t *sig)
 {
@@ -166,17 +168,22 @@ bootutil_cmp_rsasig(mbedtls_rsa_context *ctx, uint8_t *hash, uint32_t hlen,
     uint8_t db_mask[PSS_MASK_LEN];
     uint8_t h2[PSS_HLEN];
     int i;
+    int rc = 0;
+    fih_int fih_rc = FIH_FAILURE;
 
     if (ctx->len != PSS_EMLEN || PSS_EMLEN > MBEDTLS_MPI_MAX_SIZE) {
-        return -1;
+        rc = -1;
+        goto out;
     }
 
     if (hlen != PSS_HLEN) {
-        return -1;
+        rc = -1;
+        goto out;
     }
 
     if (mbedtls_rsa_public(ctx, sig, em)) {
-        return -1;
+        rc = -1;
+        goto out;
     }
 
     /*
@@ -204,7 +211,8 @@ bootutil_cmp_rsasig(mbedtls_rsa_context *ctx, uint8_t *hash, uint32_t hlen,
      * 0xbc, output inconsistent and stop.
      */
     if (em[PSS_EMLEN - 1] != 0xbc) {
-        return -1;
+        rc = -1;
+        goto out;
     }
 
     /* Step 5.  Let maskedDB be the leftmost emLen - hLen - 1 octets
@@ -244,12 +252,14 @@ bootutil_cmp_rsasig(mbedtls_rsa_context *ctx, uint8_t *hash, uint32_t hlen,
      * hexadecimal value 0x01, output "inconsistent" and stop. */
     for (i = 0; i < PSS_MASK_ZERO_COUNT; i++) {
         if (db_mask[i] != 0) {
-            return -1;
+            rc = -1;
+            goto out;
         }
     }
 
     if (db_mask[PSS_MASK_ONE_POS] != 1) {
-        return -1;
+        rc = -1;
+        goto out;
     }
 
     /* Step 11. Let salt be the last sLen octets of DB */
@@ -266,19 +276,23 @@ bootutil_cmp_rsasig(mbedtls_rsa_context *ctx, uint8_t *hash, uint32_t hlen,
 
     /* Step 14.  If H = H', output "consistent".  Otherwise, output
      * "inconsistent". */
-    if (memcmp(h2, &em[PSS_HASH_OFFSET], PSS_HLEN) != 0) {
-        return -1;
+    FIH_CALL(boot_fih_memequal, fih_rc, h2, &em[PSS_HASH_OFFSET], PSS_HLEN);
+
+out:
+    if (rc) {
+        fih_rc = fih_int_encode(rc);
     }
 
-    return 0;
+    FIH_RET(fih_rc);
 }
 
-int
+fih_int
 bootutil_verify_sig(uint8_t *hash, uint32_t hlen, uint8_t *sig, size_t slen,
   uint8_t key_id)
 {
     mbedtls_rsa_context ctx;
     int rc;
+    fih_int fih_rc = FIH_FAILURE;
     uint8_t *cp;
     uint8_t *end;
 
@@ -290,11 +304,13 @@ bootutil_verify_sig(uint8_t *hash, uint32_t hlen, uint8_t *sig, size_t slen,
     rc = bootutil_parse_rsakey(&ctx, &cp, end);
     if (rc || slen != ctx.len) {
         mbedtls_rsa_free(&ctx);
-        return rc;
+        goto out;
     }
-    rc = bootutil_cmp_rsasig(&ctx, hash, hlen, sig);
+    FIH_CALL(bootutil_cmp_rsasig, fih_rc, &ctx, hash, hlen, sig);
+
+out:
     mbedtls_rsa_free(&ctx);
 
-    return rc;
+    FIH_RET(fih_rc);
 }
 #endif /* MCUBOOT_SIGN_RSA */

--- a/boot/cypress/MCUBootApp/cy_security_cnt.c
+++ b/boot/cypress/MCUBootApp/cy_security_cnt.c
@@ -17,15 +17,15 @@
 #include "bootutil/security_cnt.h"
 #include <stdint.h>
 
-int32_t
+fih_int
 boot_nv_security_counter_init(void)
 {
     /* Do nothing. */
     return 0;
 }
 
-int32_t
-boot_nv_security_counter_get(uint32_t image_id, uint32_t *security_cnt)
+fih_int
+boot_nv_security_counter_get(uint32_t image_id, fih_int *security_cnt)
 {
     (void)image_id;
     *security_cnt = 30;

--- a/boot/cypress/MCUBootApp/main.c
+++ b/boot/cypress/MCUBootApp/main.c
@@ -36,6 +36,9 @@
 
 #include "bootutil/bootutil_log.h"
 
+#include "bootutil/fault_injection_hardening.h"
+#include "bootutil/fault_injection_hardening_delay_rng.h"
+
 /* Define pins for UART debug output */
 #define CYBSP_UART_ENABLED 1U
 #define CYBSP_UART_HW SCB5
@@ -75,6 +78,7 @@ int main(void)
     struct boot_rsp rsp;
     cy_rslt_t rc = CY_RSLT_TYPE_ERROR;
     bool boot_succeeded = false;
+    fih_int fih_rc = FIH_FAILURE;
 
     init_cycfg_clocks();
     init_cycfg_peripherals();
@@ -113,7 +117,9 @@ int main(void)
     if (CY_SMIF_SUCCESS == rc)
 #endif
     {
-        if (boot_go(&rsp) == 0)
+
+        FIH_CALL(boot_go, fih_rc, &rsp);
+        if (fih_eq(fih_rc, FIH_SUCCESS))
         {
             BOOT_LOG_INF("User Application validated successfully");
             do_boot(&rsp);

--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -100,7 +100,14 @@ zephyr_library_sources(
   ${BOOT_DIR}/bootutil/src/image_ec256.c
   ${BOOT_DIR}/bootutil/src/image_ed25519.c
   ${BOOT_DIR}/bootutil/src/bootutil_misc.c
+  ${BOOT_DIR}/bootutil/src/fault_injection_hardening.c
   )
+
+if(CONFIG_BOOT_FIH_PROFILE_HIGH)
+zephyr_library_sources(
+  ${BOOT_DIR}/bootutil/src/fault_injection_hardening_delay_rng_mbedtls.c
+  )
+endif()
 
 if(CONFIG_SINGLE_APPLICATION_SLOT)
 zephyr_library_sources(
@@ -116,7 +123,6 @@ zephyr_library_sources(
   ${BOOT_DIR}/bootutil/src/caps.c
   )
 endif()
-
 
 if(CONFIG_BOOT_SIGNATURE_TYPE_ECDSA_P256 OR CONFIG_BOOT_ENCRYPT_EC256)
   zephyr_library_include_directories(

--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -297,6 +297,42 @@ config BOOT_SHARE_DATA
 	bool "Save application specific data in shared memory area"
 	default n
 
+choice
+	prompt "Fault injection hardening profile"
+	default BOOT_FIH_PROFILE_OFF
+
+config BOOT_FIH_PROFILE_OFF
+	bool "No hardening against hardware level fault injection"
+	help
+	  No hardening in SW against hardware level fault injection: power or
+	  clock glitching, etc.
+
+config BOOT_FIH_PROFILE_LOW
+	bool "Moderate level hardening against hardware level fault injection"
+	help
+	  Moderate level hardening: Long global fail loop to avoid break out,
+	  control flow integrity check to discover discrepancy in expected code
+	  flow.
+
+config BOOT_FIH_PROFILE_MEDIUM
+	bool "Medium level hardening against hardware level fault injection"
+	help
+	  Medium level hardening: Long global fail loop to avoid break out,
+	  control flow integrity check to discover discrepancy in expected code
+	  flow, double variables to discover register or memory corruption.
+
+config BOOT_FIH_PROFILE_HIGH
+	bool "Maximum level hardening against hardware level fault injection"
+	select MBEDTLS
+	help
+	  Maximum level hardening: Long global fail loop to avoid break out,
+	  control flow integrity check to discover discrepancy in expected code
+	  flow, double variables to discover register or memory corruption, random
+	  delays to make code execution less predictable. Random delays requires an
+	  entropy source.
+
+endchoice
+
 config BOOT_WAIT_FOR_USB_DFU
 	bool "Wait for a prescribed duration to see if USB DFU is invoked"
 	default n

--- a/boot/zephyr/include/mcuboot_config/mcuboot_config.h
+++ b/boot/zephyr/include/mcuboot_config/mcuboot_config.h
@@ -125,6 +125,22 @@
 #define MCUBOOT_DATA_SHARING
 #endif
 
+#ifdef CONFIG_BOOT_FIH_PROFILE_OFF
+#define MCUBOOT_FIH_PROFILE_OFF
+#endif
+
+#ifdef CONFIG_BOOT_FIH_PROFILE_LOW
+#define MCUBOOT_FIH_PROFILE_LOW
+#endif
+
+#ifdef CONFIG_BOOT_FIH_PROFILE_MEDIUM
+#define MCUBOOT_FIH_PROFILE_MEDIUM
+#endif
+
+#ifdef CONFIG_BOOT_FIH_PROFILE_HIGH
+#define MCUBOOT_FIH_PROFILE_HIGH
+#endif
+
 /*
  * Enabling this option uses newer flash map APIs. This saves RAM and
  * avoids deprecated API usage.

--- a/boot/zephyr/single_loader.c
+++ b/boot/zephyr/single_loader.c
@@ -2,12 +2,15 @@
  * SPDX-License-Identifier: Apache-2.0
  *
  * Copyright (c) 2020 Nordic Semiconductor ASA
+ * Copyright (c) 2020 Arm Limited
  */
 
 #include <assert.h>
 #include "bootutil/image.h"
 #include "bootutil_priv.h"
 #include "bootutil/bootutil_log.h"
+#include "bootutil/fault_injection_hardening.h"
+#include "bootutil/fault_injection_hardening_delay_rng.h"
 
 #include "mcuboot_config/mcuboot_config.h"
 
@@ -24,13 +27,14 @@ static struct image_header _hdr = { 0 };
  * @param[in]	fa_p	flash area pointer
  * @param[in]	hdr	boot image header pointer
  *
- * @return		0 on success, error code otherwise
+ * @return		FIH_SUCCESS on success, error code otherwise
  */
-inline static int
+inline static fih_int
 boot_image_validate(const struct flash_area *fa_p,
                     struct image_header *hdr)
 {
     static uint8_t tmpbuf[BOOT_TMPBUF_SZ];
+    fih_int fih_rc = FIH_FAILURE;
 
     /* NOTE: The enc-state pointer may be NULL only because when there is
      * only one image (BOOT_IMAGE_NUMBER == 1), the code that uses the
@@ -38,12 +42,10 @@ boot_image_validate(const struct flash_area *fa_p,
      * is excluded from compilation.
      */
     /* Validate hash */
-    if (bootutil_img_validate(NULL, 0, hdr, fa_p, tmpbuf,
-                              BOOT_TMPBUF_SZ, NULL, 0, NULL)) {
-        return BOOT_EBADIMAGE;
-    }
+    FIH_CALL(bootutil_img_validate, fih_rc, NULL, 0, hdr, fa_p, tmpbuf,
+             BOOT_TMPBUF_SZ, NULL, 0, NULL);
 
-    return 0;
+    FIH_RET(fih_rc);
 }
 #endif /* MCUBOOT_VALIDATE_PRIMARY_SLOT */
 
@@ -95,12 +97,13 @@ boot_image_load_header(const struct flash_area *fa_p,
  *
  * @parami[out]	rsp	Parameters for booting image, on success
  *
- * @return		0 on success, error code otherwise.
+ * @return		FIH_SUCCESS on success; nonzero on failure.
  */
-int
+fih_int
 boot_go(struct boot_rsp *rsp)
 {
     int rc = -1;
+    fih_int fih_rc = FIH_FAILURE;
 
     rc = flash_area_open(FLASH_AREA_IMAGE_PRIMARY(0), &_fa_p);
     assert(rc == 0);
@@ -110,10 +113,12 @@ boot_go(struct boot_rsp *rsp)
         goto out;
 
 #ifdef MCUBOOT_VALIDATE_PRIMARY_SLOT
-    rc = boot_image_validate(_fa_p, &_hdr);
-    if (rc != 0) {
+    FIH_CALL(boot_image_validate, fih_rc, _fa_p, &_hdr);
+    if (fih_not_eq(fih_rc, FIH_SUCCESS)) {
         goto out;
     }
+#else
+    fih_rc = FIH_SUCCESS;
 #endif /* MCUBOOT_VALIDATE_PRIMARY_SLOT */
 
     rsp->br_flash_dev_id = _fa_p->fa_device_id;
@@ -122,5 +127,6 @@ boot_go(struct boot_rsp *rsp)
 
 out:
     flash_area_close(_fa_p);
-    return rc;
+
+    FIH_RET(fih_rc);
 }

--- a/sim/mcuboot-sys/build.rs
+++ b/sim/mcuboot-sys/build.rs
@@ -270,6 +270,7 @@ fn main() {
     conf.file("../../boot/bootutil/src/caps.c");
     conf.file("../../boot/bootutil/src/bootutil_misc.c");
     conf.file("../../boot/bootutil/src/tlv.c");
+    conf.file("../../boot/bootutil/src/fault_injection_hardening.c");
     conf.file("csupport/run.c");
     conf.include("../../boot/bootutil/include");
     conf.include("csupport");


### PR DESCRIPTION
Adding SW counter measures against fault injection attacks in HW. These attacks could be clock or power glitching, EM pulse, laser beam, temperature change.  The goal of the attacker is is to execute unauthenticated code on the device.  The expectation of the attacker that due to these injected faults the CPU will change its normal behaviour and in this way create a benefit for the attacker to bypass secure boot and image authentication. The potential differences in the CPU behaviour could be one or more instruction skip, modifying register content, corrupting memory read, corrupting instruction decoding, resetting bits in program status register. 

The SW counter measure are not guaranteeing 100% protection against all HW attack but make harder to bypass image authentication. The SW counter measures are disabled by default they can be enabled with MCUBOOT_FIH_PROFILE_* macros. Currently there are defined 4 protection level: none, moderate, medium, max. These are enabling more and more SW counter measures. These are only added to the generic part of MCUboot files in `boot/bootutil/src`. Currently only the critical call path is hardened where a corruption of a single `if (ret)` statement can be accept an unauthenticated image. The crypto (mbed-crypto, tinycrypt) libraries are independent projects from MCUboot so they are not changed. They might contains similar feature or not, need to be checked individually.

Main hardening code are in :

- boot/bootutil/include/bootutil/fault_injection_hardening.h
- boot/bootutil/src/fault_injection_hardening.c