### PR TITLE
Turn off cache for Cortex M7 before rebooting

### DIFF
--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -128,6 +128,13 @@ static void do_boot(struct boot_rsp *rsp)
     vt = (struct arm_vector_table *)(flash_base +
                                      rsp->br_image_off +
                                      rsp->br_hdr->ih_hdr_size);
+
+#ifdef CONFIG_CPU_CORTEX_M7
+    /* Disable instruction cache and data cache before chain-load the application */
+    SCB_DisableDCache();
+    SCB_DisableICache();
+#endif
+
     irq_lock();
 #ifdef CONFIG_SYS_CLOCK_EXISTS
     sys_clock_disable();


### PR DESCRIPTION
On Cortex M7, and NXP i.MX RT 1020 specifically, MCUBOOT will fail after loading a new image if the instruction cache is enabled. This works for us and might help others, but I need help to figure out where to do this, and what ifdefs to use to turn it on. Also, I'm not sure if the ARM_MPU_Disable thing is really needed.