### PR TITLE
imgtool: Print image digest during verify

### DIFF
--- a/scripts/imgtool/image.py
+++ b/scripts/imgtool/image.py
@@ -529,12 +529,12 @@ class Image():
         version = struct.unpack('BBHI', b[20:28])
 
         if magic != IMAGE_MAGIC:
-            return VerifyResult.INVALID_MAGIC, None
+            return VerifyResult.INVALID_MAGIC, None, None
 
         tlv_info = b[header_size+img_size:header_size+img_size+TLV_INFO_SIZE]
         magic, tlv_tot = struct.unpack('HH', tlv_info)
         if magic != TLV_INFO_MAGIC:
-            return VerifyResult.INVALID_TLV_INFO_MAGIC, None
+            return VerifyResult.INVALID_TLV_INFO_MAGIC, None, None
 
         sha = hashlib.sha256()
         sha.update(b[:header_size+img_size])
@@ -550,9 +550,9 @@ class Image():
                 off = tlv_off + TLV_SIZE
                 if digest == b[off:off+tlv_len]:
                     if key is None:
-                        return VerifyResult.OK, version
+                        return VerifyResult.OK, version, digest
                 else:
-                    return VerifyResult.INVALID_HASH, None
+                    return VerifyResult.INVALID_HASH, None, None
             elif key is not None and tlv_type == TLV_VALUES[key.sig_tlv()]:
                 off = tlv_off + TLV_SIZE
                 tlv_sig = b[off:off+tlv_len]
@@ -562,9 +562,9 @@ class Image():
                         key.verify(tlv_sig, payload)
                     else:
                         key.verify_digest(tlv_sig, digest)
-                    return VerifyResult.OK, version
+                    return VerifyResult.OK, version, digest
                 except InvalidSignature:
                     # continue to next TLV
                     pass
             tlv_off += TLV_SIZE + tlv_len
-        return VerifyResult.INVALID_SIGNATURE, None
+        return VerifyResult.INVALID_SIGNATURE, None, None

--- a/scripts/imgtool/main.py
+++ b/scripts/imgtool/main.py
@@ -140,10 +140,11 @@ def getpriv(key, minimal):
 @click.command(help="Check that signed image can be verified by given key")
 def verify(key, imgfile):
     key = load_key(key) if key else None
-    ret, version = image.Image.verify(imgfile, key)
+    ret, version, digest = image.Image.verify(imgfile, key)
     if ret == image.VerifyResult.OK:
         print("Image was correctly validated")
         print("Image version: {}.{}.{}+{}".format(*version))
+        print("Image digest: {}".format(digest.hex()))
         return
     elif ret == image.VerifyResult.INVALID_MAGIC:
         print("Invalid image magic; is this an MCUboot image?")


### PR DESCRIPTION
In an effort to create a script to do firmware based on an URL, I could
not easily retrieve the image digest. `newtmgr` needs the hash when
marking a image for testing.