### PR TITLE
RAM loading upgrade mode

### DIFF
--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -28,6 +28,8 @@
 #ifndef H_BOOTUTIL_PRIV_
 #define H_BOOTUTIL_PRIV_
 
+#include <string.h>
+
 #include "sysflash/sysflash.h"
 
 #include <flash_map_backend/flash_map_backend.h>
@@ -68,13 +70,15 @@ struct flash_area;
 
 #if (defined(MCUBOOT_OVERWRITE_ONLY) + \
      defined(MCUBOOT_SWAP_USING_MOVE) + \
-     defined(MCUBOOT_DIRECT_XIP)) > 1
-#error "Please enable only one of MCUBOOT_OVERWRITE_ONLY, MCUBOOT_SWAP_USING_MOVE or MCUBOOT_DIRECT_XIP"
+     defined(MCUBOOT_DIRECT_XIP) + \
+     defined(MCUBOOT_RAM_LOAD)) > 1
+#error "Please enable only one of MCUBOOT_OVERWRITE_ONLY, MCUBOOT_SWAP_USING_MOVE, MCUBOOT_DIRECT_XIP or MCUBOOT_RAM_LOAD"
 #endif
 
 #if !defined(MCUBOOT_OVERWRITE_ONLY) && \
     !defined(MCUBOOT_SWAP_USING_MOVE) && \
-    !defined(MCUBOOT_DIRECT_XIP)
+    !defined(MCUBOOT_DIRECT_XIP) && \
+    !defined(MCUBOOT_RAM_LOAD)
 #define MCUBOOT_SWAP_USING_SCRATCH 1
 #endif
 
@@ -170,18 +174,18 @@ struct boot_swap_state {
 
 _Static_assert(BOOT_IMAGE_NUMBER > 0, "Invalid value for BOOT_IMAGE_NUMBER");
 
-#if !defined(MCUBOOT_DIRECT_XIP)
-#define IS_IN_XIP_MODE()    0
+#if !defined(MCUBOOT_DIRECT_XIP) && !defined(MCUBOOT_RAM_LOAD)
+#define ARE_SLOTS_EQUIVALENT()    0
 #else
-#define IS_IN_XIP_MODE()    1
+#define ARE_SLOTS_EQUIVALENT()    1
 
 #if (BOOT_IMAGE_NUMBER != 1)
-#error "The MCUBOOT_DIRECT_XIP mode only supports single-image boot (MCUBOOT_IMAGE_NUMBER=1)."
+#error "The MCUBOOT_DIRECT_XIP and MCUBOOT_RAM_LOAD mode only supports single-image boot (MCUBOOT_IMAGE_NUMBER=1)."
 #endif
 #ifdef MCUBOOT_ENC_IMAGES
-#error "Image encryption (MCUBOOT_ENC_IMAGES) is not supported when MCUBOOT_DIRECT_XIP mode is selected."
+#error "Image encryption (MCUBOOT_ENC_IMAGES) is not supported when MCUBOOT_DIRECT_XIP or MCUBOOT_RAM_LOAD mode is selected."
 #endif
-#endif /* MCUBOOT_DIRECT_XIP */
+#endif /* MCUBOOT_DIRECT_XIP || MCUBOOT_RAM_LOAD */
 
 #define BOOT_MAX_IMG_SECTORS       MCUBOOT_MAX_IMG_SECTORS
 
@@ -438,6 +442,15 @@ boot_img_sector_off(const struct boot_loader_state *state, size_t slot,
 }
 
 #endif  /* !defined(MCUBOOT_USE_FLASH_AREA_GET_SECTORS) */
+
+#ifdef MCUBOOT_RAM_LOAD
+#define LOAD_IMAGE_DATA(hdr, fap, start, output, size)       \
+    (memcpy((output),(void*)((hdr)->ih_load_addr + (start)), \
+    (size)) != (output))
+#else
+#define LOAD_IMAGE_DATA(hdr, fap, start, output, size)       \
+    (flash_area_read((fap), (start), (output), (size)))
+#endif /* MCUBOOT_RAM_LOAD */
 
 #ifdef __cplusplus
 }

--- a/boot/bootutil/src/swap_misc.c
+++ b/boot/bootutil/src/swap_misc.c
@@ -32,7 +32,6 @@
 MCUBOOT_LOG_MODULE_DECLARE(mcuboot);
 
 #if defined(MCUBOOT_SWAP_USING_SCRATCH) || defined(MCUBOOT_SWAP_USING_MOVE)
-
 int
 swap_erase_trailer_sectors(const struct boot_loader_state *state,
                            const struct flash_area *fap)

--- a/boot/bootutil/src/swap_scratch.c
+++ b/boot/bootutil/src/swap_scratch.c
@@ -82,7 +82,7 @@ done:
     return rc;
 }
 
-#if !defined(MCUBOOT_DIRECT_XIP)
+#if !defined(MCUBOOT_DIRECT_XIP) && !defined(MCUBOOT_RAM_LOAD)
 /**
  * Reads the status of a partially-completed swap, if any.  This is necessary
  * to recover in case the boot lodaer was reset in the middle of a swap
@@ -724,6 +724,6 @@ swap_run(struct boot_loader_state *state, struct boot_status *bs,
 }
 #endif /* !MCUBOOT_OVERWRITE_ONLY */
 
-#endif /* !MCUBOOT_DIRECT_XIP */
+#endif /* !MCUBOOT_DIRECT_XIP && !MCUBOOT_RAM_LOAD */
 
 #endif /* !MCUBOOT_SWAP_USING_MOVE */

--- a/boot/bootutil/src/tlv.c
+++ b/boot/bootutil/src/tlv.c
@@ -2,6 +2,7 @@
  * SPDX-License-Identifier: Apache-2.0
  *
  * Copyright (c) 2019 JUUL Labs
+ * Copyright (c) 2020 Arm Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,7 +47,7 @@ bootutil_tlv_iter_begin(struct image_tlv_iter *it, const struct image_header *hd
     }
 
     off_ = BOOT_TLV_OFF(hdr);
-    if (flash_area_read(fap, off_, &info, sizeof(info))) {
+    if (LOAD_IMAGE_DATA(hdr, fap, off_, &info, sizeof(info))) {
         return -1;
     }
 
@@ -55,7 +56,8 @@ bootutil_tlv_iter_begin(struct image_tlv_iter *it, const struct image_header *hd
             return -1;
         }
 
-        if (flash_area_read(fap, off_ + info.it_tlv_tot, &info, sizeof(info))) {
+        if (LOAD_IMAGE_DATA(hdr, fap, off_ + info.it_tlv_tot,
+                            &info, sizeof(info))) {
             return -1;
         }
     } else if (hdr->ih_protect_tlv_size != 0) {
@@ -105,7 +107,7 @@ bootutil_tlv_iter_next(struct image_tlv_iter *it, uint32_t *off, uint16_t *len,
             it->tlv_off += sizeof(struct image_tlv_info);
         }
 
-        rc = flash_area_read(it->fap, it->tlv_off, &tlv, sizeof tlv);
+        rc = LOAD_IMAGE_DATA(it->hdr, it->fap, it->tlv_off, &tlv, sizeof tlv);
         if (rc) {
             return -1;
         }

--- a/samples/mcuboot_config/mcuboot_config.template.h
+++ b/samples/mcuboot_config/mcuboot_config.template.h
@@ -58,6 +58,9 @@
 /* Uncomment to enable the direct-xip code path. */
 /* #define MCUBOOT_DIRECT_XIP */
 
+/* Uncomment to enable the ram-load code path. */
+/* #define MCUBOOT_RAM_LOAD */
+
 /*
  * Cryptographic settings
  *

--- a/scripts/imgtool/main.py
+++ b/scripts/imgtool/main.py
@@ -245,7 +245,7 @@ class BasedIntParamType(click.ParamType):
                    'was set.')
 @click.option('-E', '--encrypt', metavar='filename',
               help='Encrypt image using the provided public key. '
-                   '(Not supported in direct-xip mode.)')
+                   '(Not supported in direct-xip or ram-load mode.)')
 @click.option('-e', '--endian', type=click.Choice(['little', 'big']),
               default='little', help="Select little or big endian")
 @click.option('--overwrite-only', default=False, is_flag=True,


### PR DESCRIPTION
This PR introduces the ram-loading mode in addition to the other
upgrade modes (swap strategies, overwrite-only, direct-XIP). When
ram-loading is enabled with the MCUBOOT_RAM_LOADING option, mcuboot
selects the newest valid image based on the image version numbers from
the image header, thereafter the selected image loaded to the RAM and
executed from there. Load address is extracted from the image header.
Therefore the images must be linked to the RAM memory region.
The ram-loading mode is very similar to the direct-XIP mode, main
difference is to load the newest image to the RAM beforehand the
authentication and execution. Similar to direct-XIP mode either
of the primary and the secondary slots can hold the active image.

Ram-loading can be useful in case of a bit more powerful SoC, which
is not constrained in terms of internal RAM. It could be that image
is stored in external and therefore untrusted flash. Loading image
to internal (trusted) RAM is essential from the security point
of view the system. Furthermore execution from internal RAM is much
faster than from external flash.