### PR TITLE
Separate Zephyr sample build

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/JuulLabs-OSS/mcuboot
+
+go 1.14

--- a/samples/zephyr/.gitignore
+++ b/samples/zephyr/.gitignore
@@ -1,1 +1,2 @@
 *.bin
+test-images.zip

--- a/samples/zephyr/mcutests/mcutests.go
+++ b/samples/zephyr/mcutests/mcutests.go
@@ -4,11 +4,13 @@ package mcutests // github.com/JuulLabs-OSS/mcuboot/samples/zephyr/mcutests
 // The main driver of this consists of a series of tests.  Each test
 // then contains a series of commands and expect results.
 var Tests = []struct {
-	Name  string
-	Tests []OneTest
+	Name      string
+	ShortName string
+	Tests     []OneTest
 }{
 	{
-		Name: "Good RSA",
+		Name:      "Good RSA",
+		ShortName: "good-rsa",
 		Tests: []OneTest{
 			{
 				Commands: [][]string{
@@ -38,7 +40,8 @@ var Tests = []struct {
 		},
 	},
 	{
-		Name: "Good ECDSA",
+		Name:      "Good ECDSA",
+		ShortName: "good-ecdsa",
 		Tests: []OneTest{
 			{
 				Commands: [][]string{
@@ -68,7 +71,8 @@ var Tests = []struct {
 		},
 	},
 	{
-		Name: "Overwrite",
+		Name:      "Overwrite",
+		ShortName: "overwrite",
 		Tests: []OneTest{
 			{
 				Commands: [][]string{
@@ -98,7 +102,8 @@ var Tests = []struct {
 		},
 	},
 	{
-		Name: "Bad RSA",
+		Name:      "Bad RSA",
+		ShortName: "bad-rsa-upgrade",
 		Tests: []OneTest{
 			{
 				Commands: [][]string{
@@ -128,7 +133,8 @@ var Tests = []struct {
 		},
 	},
 	{
-		Name: "Bad RSA",
+		Name:      "Bad RSA",
+		ShortName: "bad-ecdsa-upgrade",
 		Tests: []OneTest{
 			{
 				Commands: [][]string{
@@ -158,7 +164,8 @@ var Tests = []struct {
 		},
 	},
 	{
-		Name: "No bootcheck",
+		Name:      "No bootcheck",
+		ShortName: "no-bootcheck",
 		Tests: []OneTest{
 			{
 				Commands: [][]string{
@@ -188,7 +195,8 @@ var Tests = []struct {
 		},
 	},
 	{
-		Name: "Wrong RSA",
+		Name:      "Wrong RSA",
+		ShortName: "wrong-rsa",
 		Tests: []OneTest{
 			{
 				Commands: [][]string{
@@ -218,7 +226,8 @@ var Tests = []struct {
 		},
 	},
 	{
-		Name: "Wrong ECDSA",
+		Name:      "Wrong ECDSA",
+		ShortName: "wrong-ecdsa",
 		Tests: []OneTest{
 			{
 				Commands: [][]string{

--- a/samples/zephyr/mcutests/mcutests.go
+++ b/samples/zephyr/mcutests/mcutests.go
@@ -1,0 +1,255 @@
+// Package mcutests
+package mcutests // github.com/JuulLabs-OSS/mcuboot/samples/zephyr/mcutests
+
+// The main driver of this consists of a series of tests.  Each test
+// then contains a series of commands and expect results.
+var Tests = []struct {
+	Name  string
+	Tests []OneTest
+}{
+	{
+		Name: "Good RSA",
+		Tests: []OneTest{
+			{
+				Commands: [][]string{
+					{"make", "test-good-rsa"},
+					{"make", "flash_boot"},
+				},
+				Expect: "Unable to find bootable image",
+			},
+			{
+				Commands: [][]string{
+					{"make", "flash_hello1"},
+				},
+				Expect: "Hello World from hello1",
+			},
+			{
+				Commands: [][]string{
+					{"make", "flash_hello2"},
+				},
+				Expect: "Hello World from hello2",
+			},
+			{
+				Commands: [][]string{
+					{"pyocd", "commander", "-c", "reset"},
+				},
+				Expect: "Hello World from hello1",
+			},
+		},
+	},
+	{
+		Name: "Good ECDSA",
+		Tests: []OneTest{
+			{
+				Commands: [][]string{
+					{"make", "test-good-ecdsa"},
+					{"make", "flash_boot"},
+				},
+				Expect: "Unable to find bootable image",
+			},
+			{
+				Commands: [][]string{
+					{"make", "flash_hello1"},
+				},
+				Expect: "Hello World from hello1",
+			},
+			{
+				Commands: [][]string{
+					{"make", "flash_hello2"},
+				},
+				Expect: "Hello World from hello2",
+			},
+			{
+				Commands: [][]string{
+					{"pyocd", "commander", "-c", "reset"},
+				},
+				Expect: "Hello World from hello1",
+			},
+		},
+	},
+	{
+		Name: "Overwrite",
+		Tests: []OneTest{
+			{
+				Commands: [][]string{
+					{"make", "test-overwrite"},
+					{"make", "flash_boot"},
+				},
+				Expect: "Unable to find bootable image",
+			},
+			{
+				Commands: [][]string{
+					{"make", "flash_hello1"},
+				},
+				Expect: "Hello World from hello1",
+			},
+			{
+				Commands: [][]string{
+					{"make", "flash_hello2"},
+				},
+				Expect: "Hello World from hello2",
+			},
+			{
+				Commands: [][]string{
+					{"pyocd", "commander", "-c", "reset"},
+				},
+				Expect: "Hello World from hello2",
+			},
+		},
+	},
+	{
+		Name: "Bad RSA",
+		Tests: []OneTest{
+			{
+				Commands: [][]string{
+					{"make", "test-bad-rsa-upgrade"},
+					{"make", "flash_boot"},
+				},
+				Expect: "Unable to find bootable image",
+			},
+			{
+				Commands: [][]string{
+					{"make", "flash_hello1"},
+				},
+				Expect: "Hello World from hello1",
+			},
+			{
+				Commands: [][]string{
+					{"make", "flash_hello2"},
+				},
+				Expect: "Hello World from hello1",
+			},
+			{
+				Commands: [][]string{
+					{"pyocd", "commander", "-c", "reset"},
+				},
+				Expect: "Hello World from hello1",
+			},
+		},
+	},
+	{
+		Name: "Bad RSA",
+		Tests: []OneTest{
+			{
+				Commands: [][]string{
+					{"make", "test-bad-ecdsa-upgrade"},
+					{"make", "flash_boot"},
+				},
+				Expect: "Unable to find bootable image",
+			},
+			{
+				Commands: [][]string{
+					{"make", "flash_hello1"},
+				},
+				Expect: "Hello World from hello1",
+			},
+			{
+				Commands: [][]string{
+					{"make", "flash_hello2"},
+				},
+				Expect: "Hello World from hello1",
+			},
+			{
+				Commands: [][]string{
+					{"pyocd", "commander", "-c", "reset"},
+				},
+				Expect: "Hello World from hello1",
+			},
+		},
+	},
+	{
+		Name: "No bootcheck",
+		Tests: []OneTest{
+			{
+				Commands: [][]string{
+					{"make", "test-no-bootcheck"},
+					{"make", "flash_boot"},
+				},
+				Expect: "Unable to find bootable image",
+			},
+			{
+				Commands: [][]string{
+					{"make", "flash_hello1"},
+				},
+				Expect: "Hello World from hello1",
+			},
+			{
+				Commands: [][]string{
+					{"make", "flash_hello2"},
+				},
+				Expect: "Hello World from hello1",
+			},
+			{
+				Commands: [][]string{
+					{"pyocd", "commander", "-c", "reset"},
+				},
+				Expect: "Hello World from hello1",
+			},
+		},
+	},
+	{
+		Name: "Wrong RSA",
+		Tests: []OneTest{
+			{
+				Commands: [][]string{
+					{"make", "test-wrong-rsa"},
+					{"make", "flash_boot"},
+				},
+				Expect: "Unable to find bootable image",
+			},
+			{
+				Commands: [][]string{
+					{"make", "flash_hello1"},
+				},
+				Expect: "Hello World from hello1",
+			},
+			{
+				Commands: [][]string{
+					{"make", "flash_hello2"},
+				},
+				Expect: "Hello World from hello1",
+			},
+			{
+				Commands: [][]string{
+					{"pyocd", "commander", "-c", "reset"},
+				},
+				Expect: "Hello World from hello1",
+			},
+		},
+	},
+	{
+		Name: "Wrong ECDSA",
+		Tests: []OneTest{
+			{
+				Commands: [][]string{
+					{"make", "test-wrong-ecdsa"},
+					{"make", "flash_boot"},
+				},
+				Expect: "Unable to find bootable image",
+			},
+			{
+				Commands: [][]string{
+					{"make", "flash_hello1"},
+				},
+				Expect: "Hello World from hello1",
+			},
+			{
+				Commands: [][]string{
+					{"make", "flash_hello2"},
+				},
+				Expect: "Hello World from hello1",
+			},
+			{
+				Commands: [][]string{
+					{"pyocd", "commander", "-c", "reset"},
+				},
+				Expect: "Hello World from hello1",
+			},
+		},
+	},
+}
+
+type OneTest struct {
+	Commands [][]string
+	Expect   string
+}

--- a/samples/zephyr/mcutests/mcutests.go
+++ b/samples/zephyr/mcutests/mcutests.go
@@ -13,8 +13,10 @@ var Tests = []struct {
 		ShortName: "good-rsa",
 		Tests: []OneTest{
 			{
-				Commands: [][]string{
+				Build: [][]string{
 					{"make", "test-good-rsa"},
+				},
+				Commands: [][]string{
 					{"make", "flash_boot"},
 				},
 				Expect: "Unable to find bootable image",
@@ -44,8 +46,10 @@ var Tests = []struct {
 		ShortName: "good-ecdsa",
 		Tests: []OneTest{
 			{
-				Commands: [][]string{
+				Build: [][]string{
 					{"make", "test-good-ecdsa"},
+				},
+				Commands: [][]string{
 					{"make", "flash_boot"},
 				},
 				Expect: "Unable to find bootable image",
@@ -75,8 +79,10 @@ var Tests = []struct {
 		ShortName: "overwrite",
 		Tests: []OneTest{
 			{
-				Commands: [][]string{
+				Build: [][]string{
 					{"make", "test-overwrite"},
+				},
+				Commands: [][]string{
 					{"make", "flash_boot"},
 				},
 				Expect: "Unable to find bootable image",
@@ -106,8 +112,10 @@ var Tests = []struct {
 		ShortName: "bad-rsa-upgrade",
 		Tests: []OneTest{
 			{
-				Commands: [][]string{
+				Build: [][]string{
 					{"make", "test-bad-rsa-upgrade"},
+				},
+				Commands: [][]string{
 					{"make", "flash_boot"},
 				},
 				Expect: "Unable to find bootable image",
@@ -137,8 +145,10 @@ var Tests = []struct {
 		ShortName: "bad-ecdsa-upgrade",
 		Tests: []OneTest{
 			{
-				Commands: [][]string{
+				Build: [][]string{
 					{"make", "test-bad-ecdsa-upgrade"},
+				},
+				Commands: [][]string{
 					{"make", "flash_boot"},
 				},
 				Expect: "Unable to find bootable image",
@@ -168,8 +178,10 @@ var Tests = []struct {
 		ShortName: "no-bootcheck",
 		Tests: []OneTest{
 			{
-				Commands: [][]string{
+				Build: [][]string{
 					{"make", "test-no-bootcheck"},
+				},
+				Commands: [][]string{
 					{"make", "flash_boot"},
 				},
 				Expect: "Unable to find bootable image",
@@ -199,8 +211,10 @@ var Tests = []struct {
 		ShortName: "wrong-rsa",
 		Tests: []OneTest{
 			{
-				Commands: [][]string{
+				Build: [][]string{
 					{"make", "test-wrong-rsa"},
+				},
+				Commands: [][]string{
 					{"make", "flash_boot"},
 				},
 				Expect: "Unable to find bootable image",
@@ -230,8 +244,10 @@ var Tests = []struct {
 		ShortName: "wrong-ecdsa",
 		Tests: []OneTest{
 			{
-				Commands: [][]string{
+				Build: [][]string{
 					{"make", "test-wrong-ecdsa"},
+				},
+				Commands: [][]string{
 					{"make", "flash_boot"},
 				},
 				Expect: "Unable to find bootable image",
@@ -259,6 +275,7 @@ var Tests = []struct {
 }
 
 type OneTest struct {
+	Build    [][]string
 	Commands [][]string
 	Expect   string
 }

--- a/samples/zephyr/run-tests.go
+++ b/samples/zephyr/run-tests.go
@@ -23,6 +23,8 @@ import (
 	"os/exec"
 	"strings"
 	"time"
+
+	"github.com/JuulLabs-OSS/mcuboot/samples/zephyr/mcutests"
 )
 
 // logIn gives the pathname of the log output from the Zephyr device.
@@ -38,259 +40,6 @@ var logIn = flag.String("login", "/tmp/zephyr.out", "File name of terminal log f
 
 // Output from this test run is written to the given log file.
 var logOut = flag.String("logout", "tests.log", "Log file to write to")
-
-// The main driver of this consists of a series of tests.  Each test
-// then contains a series of commands and expect results.
-var tests = []struct {
-	name  string
-	tests []oneTest
-}{
-	{
-		name: "Good RSA",
-		tests: []oneTest{
-			{
-				commands: [][]string{
-					{"make", "test-good-rsa"},
-					{"make", "flash_boot"},
-				},
-				expect: "Unable to find bootable image",
-			},
-			{
-				commands: [][]string{
-					{"make", "flash_hello1"},
-				},
-				expect: "Hello World from hello1",
-			},
-			{
-				commands: [][]string{
-					{"make", "flash_hello2"},
-				},
-				expect: "Hello World from hello2",
-			},
-			{
-				commands: [][]string{
-					{"pyocd", "commander", "-c", "reset"},
-				},
-				expect: "Hello World from hello1",
-			},
-		},
-	},
-	{
-		name: "Good ECDSA",
-		tests: []oneTest{
-			{
-				commands: [][]string{
-					{"make", "test-good-ecdsa"},
-					{"make", "flash_boot"},
-				},
-				expect: "Unable to find bootable image",
-			},
-			{
-				commands: [][]string{
-					{"make", "flash_hello1"},
-				},
-				expect: "Hello World from hello1",
-			},
-			{
-				commands: [][]string{
-					{"make", "flash_hello2"},
-				},
-				expect: "Hello World from hello2",
-			},
-			{
-				commands: [][]string{
-					{"pyocd", "commander", "-c", "reset"},
-				},
-				expect: "Hello World from hello1",
-			},
-		},
-	},
-	{
-		name: "Overwrite",
-		tests: []oneTest{
-			{
-				commands: [][]string{
-					{"make", "test-overwrite"},
-					{"make", "flash_boot"},
-				},
-				expect: "Unable to find bootable image",
-			},
-			{
-				commands: [][]string{
-					{"make", "flash_hello1"},
-				},
-				expect: "Hello World from hello1",
-			},
-			{
-				commands: [][]string{
-					{"make", "flash_hello2"},
-				},
-				expect: "Hello World from hello2",
-			},
-			{
-				commands: [][]string{
-					{"pyocd", "commander", "-c", "reset"},
-				},
-				expect: "Hello World from hello2",
-			},
-		},
-	},
-	{
-		name: "Bad RSA",
-		tests: []oneTest{
-			{
-				commands: [][]string{
-					{"make", "test-bad-rsa-upgrade"},
-					{"make", "flash_boot"},
-				},
-				expect: "Unable to find bootable image",
-			},
-			{
-				commands: [][]string{
-					{"make", "flash_hello1"},
-				},
-				expect: "Hello World from hello1",
-			},
-			{
-				commands: [][]string{
-					{"make", "flash_hello2"},
-				},
-				expect: "Hello World from hello1",
-			},
-			{
-				commands: [][]string{
-					{"pyocd", "commander", "-c", "reset"},
-				},
-				expect: "Hello World from hello1",
-			},
-		},
-	},
-	{
-		name: "Bad RSA",
-		tests: []oneTest{
-			{
-				commands: [][]string{
-					{"make", "test-bad-ecdsa-upgrade"},
-					{"make", "flash_boot"},
-				},
-				expect: "Unable to find bootable image",
-			},
-			{
-				commands: [][]string{
-					{"make", "flash_hello1"},
-				},
-				expect: "Hello World from hello1",
-			},
-			{
-				commands: [][]string{
-					{"make", "flash_hello2"},
-				},
-				expect: "Hello World from hello1",
-			},
-			{
-				commands: [][]string{
-					{"pyocd", "commander", "-c", "reset"},
-				},
-				expect: "Hello World from hello1",
-			},
-		},
-	},
-	{
-		name: "No bootcheck",
-		tests: []oneTest{
-			{
-				commands: [][]string{
-					{"make", "test-no-bootcheck"},
-					{"make", "flash_boot"},
-				},
-				expect: "Unable to find bootable image",
-			},
-			{
-				commands: [][]string{
-					{"make", "flash_hello1"},
-				},
-				expect: "Hello World from hello1",
-			},
-			{
-				commands: [][]string{
-					{"make", "flash_hello2"},
-				},
-				expect: "Hello World from hello1",
-			},
-			{
-				commands: [][]string{
-					{"pyocd", "commander", "-c", "reset"},
-				},
-				expect: "Hello World from hello1",
-			},
-		},
-	},
-	{
-		name: "Wrong RSA",
-		tests: []oneTest{
-			{
-				commands: [][]string{
-					{"make", "test-wrong-rsa"},
-					{"make", "flash_boot"},
-				},
-				expect: "Unable to find bootable image",
-			},
-			{
-				commands: [][]string{
-					{"make", "flash_hello1"},
-				},
-				expect: "Hello World from hello1",
-			},
-			{
-				commands: [][]string{
-					{"make", "flash_hello2"},
-				},
-				expect: "Hello World from hello1",
-			},
-			{
-				commands: [][]string{
-					{"pyocd", "commander", "-c", "reset"},
-				},
-				expect: "Hello World from hello1",
-			},
-		},
-	},
-	{
-		name: "Wrong ECDSA",
-		tests: []oneTest{
-			{
-				commands: [][]string{
-					{"make", "test-wrong-ecdsa"},
-					{"make", "flash_boot"},
-				},
-				expect: "Unable to find bootable image",
-			},
-			{
-				commands: [][]string{
-					{"make", "flash_hello1"},
-				},
-				expect: "Hello World from hello1",
-			},
-			{
-				commands: [][]string{
-					{"make", "flash_hello2"},
-				},
-				expect: "Hello World from hello1",
-			},
-			{
-				commands: [][]string{
-					{"pyocd", "commander", "-c", "reset"},
-				},
-				expect: "Hello World from hello1",
-			},
-		},
-	},
-}
-
-type oneTest struct {
-	commands [][]string
-	expect   string
-}
 
 func main() {
 	err := run()
@@ -314,13 +63,13 @@ func run() error {
 	lg := bufio.NewWriter(logFile)
 	defer lg.Flush()
 
-	for _, group := range tests {
-		fmt.Printf("Running %q\n", group.name)
+	for _, group := range mcutests.Tests {
+		fmt.Printf("Running %q\n", group.Name)
 		fmt.Fprintf(lg, "-------------------------------------\n")
-		fmt.Fprintf(lg, "---- Running %q\n", group.name)
+		fmt.Fprintf(lg, "---- Running %q\n", group.Name)
 
-		for _, test := range group.tests {
-			for _, cmd := range test.commands {
+		for _, test := range group.Tests {
+			for _, cmd := range test.Commands {
 				fmt.Printf("    %s\n", cmd)
 				fmt.Fprintf(lg, "---- Run: %s\n", cmd)
 				err = runCommand(cmd, lg)
@@ -329,7 +78,7 @@ func run() error {
 				}
 			}
 
-			err = expect(lg, lines, test.expect)
+			err = expect(lg, lines, test.Expect)
 			if err != nil {
 				return err
 			}

--- a/samples/zephyr/test-compile.go
+++ b/samples/zephyr/test-compile.go
@@ -1,0 +1,156 @@
+// +build ignore
+//
+// Build all of the tests.
+//
+// Run as:
+//
+//     go run test-compile.go -out name.tar
+
+package main
+
+import (
+	"archive/zip"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"path"
+
+	"github.com/JuulLabs-OSS/mcuboot/samples/zephyr/mcutests"
+)
+
+var outFile = flag.String("out", "test-images.zip", "Name of zip file to put built tests into")
+
+func main() {
+	err := run()
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run() error {
+	flag.Parse()
+
+	zipper, err := NewBuilds()
+	if err != nil {
+		return err
+	}
+	defer zipper.Close()
+
+	for _, group := range mcutests.Tests {
+		fmt.Printf("Compiling %q\n", group.ShortName)
+		c := exec.Command("make",
+			fmt.Sprintf("test-%s", group.ShortName))
+		// TODO: Should capture the output and show it if
+		// there is an error.
+		err = c.Run()
+		if err != nil {
+			return err
+		}
+
+		err = zipper.Capture(group.ShortName)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// A Builds create a zipfile of the contents of various builds.  The
+// names will be constructed.
+type Builds struct {
+	// The file being written to.
+	file *os.File
+
+	// The zip writer writing the data.
+	zip *zip.Writer
+}
+
+func NewBuilds() (*Builds, error) {
+	name := *outFile
+	file, err := os.OpenFile(name, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0644)
+	if err != nil {
+		return nil, err
+	}
+
+	z := zip.NewWriter(file)
+
+	return &Builds{
+		file: file,
+		zip:  z,
+	}, nil
+}
+
+func (b *Builds) Close() error {
+	return b.zip.Close()
+}
+
+func (b *Builds) Capture(testName string) error {
+	// Collect stat information from the test directory, which
+	// should be close enough to make the zip file meaningful.
+	info, err := os.Stat(".")
+	if err != nil {
+		return err
+	}
+
+	header, err := zip.FileInfoHeader(info)
+	if err != nil {
+		return err
+	}
+
+	header.Name = testName + "/"
+
+	_, err = b.zip.CreateHeader(header)
+	if err != nil {
+		return err
+	}
+
+	for _, name := range []string{
+		"mcuboot.bin",
+		"signed-hello1.bin",
+		"signed-hello2.bin",
+	} {
+		err = b.add(testName, name, name)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (b *Builds) add(baseName, zipName, fileName string) error {
+	inp, err := os.Open(fileName)
+	if err != nil {
+		return err
+	}
+	defer inp.Close()
+
+	info, err := inp.Stat()
+	if err != nil {
+		return err
+	}
+
+	header, err := zip.FileInfoHeader(info)
+	if err != nil {
+		return err
+	}
+
+	header.Name = path.Join(baseName, zipName)
+	header.Method = zip.Deflate
+
+	wr, err := b.zip.CreateHeader(header)
+	if err != nil {
+		return err
+	}
+
+	_, err = io.Copy(wr, inp)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
Some changes to the test build and run process so that it is possible to build the tests and run them on separate machines (or separate containers). Without arguments, `run-tests.go` works as it did before, but now, the `tests-compile.go` can be used to build and assemble the results into a zip file, which can be transported to another system, and used with the new `-prebuilt` argument to `run-tests.go` to use the prebuilt tests rather than building them.