### PR TITLE
Cypress: Add entering deep sleep, deinit qspi periphs in MCUBootApp, code improvements

### DIFF
--- a/boot/cypress/Makefile
+++ b/boot/cypress/Makefile
@@ -193,7 +193,7 @@ clean_upgrade:
 
 run_cppcheck:
 	@echo "Performing static code analysis with Cppcheck tool..."
-	../../scripts/cpp_check.sh ../../scripts/cpp_check.dat
+	cppcheck/cppcheck.sh $(APP_NAME) $(PLATFORM) "$(DEFINES)" "$(INCLUDE_DIRS)" "$(C_FILES)" $(CPP_CHECK_SCOPE) $(BUILDCFG)
 
 gen_key_ecc256:
 	@echo Generate ECC256 keys: $(SIGN_KEY_FILE).pem and $(SIGN_KEY_FILE).pub

--- a/boot/cypress/cy_flash_pal/flash_qspi/flash_qspi.c
+++ b/boot/cypress/cy_flash_pal/flash_qspi/flash_qspi.c
@@ -473,3 +473,21 @@ uint32_t qspi_get_mem_size(void)
     return (*memCfg)->deviceCfg->memSize;
 }
 
+void qspi_deinit(uint32_t smif_id)
+{
+    Cy_SMIF_MemDeInit(QSPIPort);
+
+    Cy_SMIF_Disable(QSPIPort);
+
+    Cy_SysClk_ClkHfDisable(CY_SYSCLK_CLKHF_IN_CLKPATH2);
+
+    NVIC_DisableIRQ(smifIntConfig.intrSrc);
+    Cy_SysInt_DisconnectInterruptSource(smifIntConfig.intrSrc, smifIntConfig.cm0pSrc);
+
+    Cy_GPIO_Port_Deinit(qspi_SS_Configuration[smif_id-1].SS_Port);
+    Cy_GPIO_Port_Deinit(SCKPort);
+    Cy_GPIO_Port_Deinit(D0Port);
+    Cy_GPIO_Port_Deinit(D1Port);
+    Cy_GPIO_Port_Deinit(D2Port);
+    Cy_GPIO_Port_Deinit(D3Port);
+}

--- a/boot/cypress/cy_flash_pal/flash_qspi/flash_qspi.h
+++ b/boot/cypress/cy_flash_pal/flash_qspi/flash_qspi.h
@@ -65,4 +65,6 @@ cy_stc_smif_context_t *qspi_get_context(void);
 cy_stc_smif_mem_config_t *qspi_get_memory_config(int index);
 void qspi_dump_device(cy_stc_smif_mem_device_cfg_t *dev);
 
+void qspi_deinit(uint32_t smif_id);
+
 #endif /* __FLASH_QSPI_H__ */

--- a/boot/cypress/platforms/retarget_io_pdl/cy_retarget_io_pdl.c
+++ b/boot/cypress/platforms/retarget_io_pdl/cy_retarget_io_pdl.c
@@ -197,7 +197,7 @@ static void cy_retarget_io_putchar(char c)
 
 static cy_rslt_t cy_retarget_io_pdl_setbaud(CySCB_Type *base, uint32_t baudrate)
 {
-    cy_rslt_t status;
+    cy_rslt_t result = CY_RSLT_TYPE_ERROR;
 
     uint8_t oversample_value = 8u;
     uint8_t frac_bits = 0u;
@@ -205,31 +205,40 @@ static cy_rslt_t cy_retarget_io_pdl_setbaud(CySCB_Type *base, uint32_t baudrate)
 
     Cy_SCB_UART_Disable(base, NULL);
 
-    Cy_SysClk_PeriphDisableDivider(CY_SYSCLK_DIV_16_BIT, 0);
+    result = (cy_rslt_t) Cy_SysClk_PeriphDisableDivider(CY_SYSCLK_DIV_16_BIT, 0);
 
     divider = ((Cy_SysClk_ClkPeriGetFrequency() * (1 << frac_bits)) + ((baudrate * oversample_value) / 2)) / (baudrate * oversample_value) - 1;
 
-    status = (cy_rslt_t) Cy_SysClk_PeriphSetDivider(CY_SYSCLK_DIV_16_BIT, 0u, divider);
-
-    Cy_SysClk_PeriphEnableDivider(CY_SYSCLK_DIV_16_BIT, 0u);
+    if (result == CY_RSLT_SUCCESS)
+    {
+        result = (cy_rslt_t) Cy_SysClk_PeriphSetDivider(CY_SYSCLK_DIV_16_BIT, 0u, divider);
+    }
+    
+    if (result == CY_RSLT_SUCCESS)
+    {
+        result = Cy_SysClk_PeriphEnableDivider(CY_SYSCLK_DIV_16_BIT, 0u);
+    }
 
     Cy_SCB_UART_Enable(base);
 
-    return status;
+    return result;
 }
 
 cy_rslt_t cy_retarget_io_pdl_init(uint32_t baudrate)
 {
-    cy_rslt_t result;
+    cy_rslt_t result = CY_RSLT_TYPE_ERROR;
 
-    /* Configure and enable UART */
-    (void)Cy_SCB_UART_Init(CYBSP_UART_HW, &CYBSP_UART_config, &CYBSP_UART_context);
+    result = (cy_rslt_t)Cy_SCB_UART_Init(CYBSP_UART_HW, &CYBSP_UART_config, &CYBSP_UART_context);
 
-    cy_retarget_io_pdl_setbaud(CYBSP_UART_HW, baudrate);
+    if (result == CY_RSLT_SUCCESS)
+    {
+        result = cy_retarget_io_pdl_setbaud(CYBSP_UART_HW, baudrate);
+    }
 
-    Cy_SCB_UART_Enable(CYBSP_UART_HW);
-
-    result = CY_RSLT_SUCCESS;
+    if (result == CY_RSLT_SUCCESS)
+    {
+        Cy_SCB_UART_Enable(CYBSP_UART_HW);
+    }
 
     return result;
 }


### PR DESCRIPTION
- improved code in MCUBootApp
- added possibility to enter deep sleep mode after mcuboot app execution
- deinitialize QSPI block after app execution
- add endless loop in main function
- minor refactoring

Signed-off-by: dmiv <dmiv@cypress.com>
Signed-off-by: Roman Okhrimenko <roman.okhrimenko@cypress.com>
Signed-off-by: Taras Boretskyy <taras.boretskyy@cypress.com>