### PR TITLE
boot: bootutil: drop flash_area_read_is_empty

### DIFF
--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -326,6 +326,16 @@ int boot_read_enc_key(int image_index, uint8_t slot, struct boot_status *bs);
 #endif
 
 /**
+ * Checks that a buffer is erased according to what the erase value for the
+ * flash device provided in `flash_area` is.
+ *
+ * @returns true if the buffer is erased; false if any of the bytes is not
+ * erased, or when buffer is NULL, or when len == 0.
+ */
+bool bootutil_buffer_is_erased(const struct flash_area *area,
+                               const void *buffer, size_t len);
+
+/**
  * Safe (non-overflowing) uint32_t addition.  Returns true, and stores
  * the result in *dest if it can be done without overflow.  Otherwise,
  * returns false.

--- a/boot/bootutil/src/swap_misc.c
+++ b/boot/bootutil/src/swap_misc.c
@@ -164,8 +164,12 @@ swap_read_status(struct boot_loader_state *state, struct boot_status *bs)
     rc = swap_read_status_bytes(fap, state, bs);
     if (rc == 0) {
         off = boot_swap_info_off(fap);
-        rc = flash_area_read_is_empty(fap, off, &swap_info, sizeof swap_info);
-        if (rc == 1) {
+        rc = flash_area_read(fap, off, &swap_info, sizeof swap_info);
+        if (rc != 0) {
+            return BOOT_EFLASH;
+        }
+
+        if (bootutil_buffer_is_erased(fap, &swap_info, sizeof swap_info)) {
             BOOT_SET_SWAP_INFO(swap_info, 0, BOOT_SWAP_TYPE_NONE);
             rc = 0;
         }

--- a/boot/bootutil/src/swap_move.c
+++ b/boot/bootutil/src/swap_move.c
@@ -142,12 +142,12 @@ swap_read_status_bytes(const struct flash_area *fap,
     write_sz = BOOT_WRITE_SZ(state);
     off = boot_status_off(fap);
     for (i = max_entries; i > 0; i--) {
-        rc = flash_area_read_is_empty(fap, off + (i - 1) * write_sz, &status, 1);
+        rc = flash_area_read(fap, off + (i - 1) * write_sz, &status, 1);
         if (rc < 0) {
             return BOOT_EFLASH;
         }
 
-        if (rc == 1) {
+        if (bootutil_buffer_is_erased(fap, &status, 1)) {
             if (rc != last_rc) {
                 erased_sections++;
             }

--- a/boot/bootutil/src/swap_scratch.c
+++ b/boot/bootutil/src/swap_scratch.c
@@ -110,13 +110,13 @@ swap_read_status_bytes(const struct flash_area *fap,
     found_idx = 0;
     invalid = 0;
     for (i = 0; i < max_entries; i++) {
-        rc = flash_area_read_is_empty(fap, off + i * BOOT_WRITE_SZ(state),
+        rc = flash_area_read(fap, off + i * BOOT_WRITE_SZ(state),
                 &status, 1);
         if (rc < 0) {
             return BOOT_EFLASH;
         }
 
-        if (rc == 1) {
+        if (bootutil_buffer_is_erased(fap, &status, 1)) {
             if (found && !found_idx) {
                 found_idx = i;
             }

--- a/boot/zephyr/include/flash_map_backend/flash_map_backend.h
+++ b/boot/zephyr/include/flash_map_backend/flash_map_backend.h
@@ -82,14 +82,6 @@ int flash_area_sector_from_off(off_t off, struct flash_sector *sector);
  */
 uint8_t flash_area_erased_val(const struct flash_area *fap);
 
-/*
- * Reads len bytes from off, and checks if the read data is erased.
- *
- * Returns 1 if erased, 0 if non-erased, and -1 on failure.
- */
-int flash_area_read_is_empty(const struct flash_area *fa, uint32_t off,
-        void *dst, uint32_t len);
-
 #ifdef __cplusplus
 }
 #endif

--- a/docs/PORTING.md
+++ b/docs/PORTING.md
@@ -119,11 +119,6 @@ int     flash_area_erase(const struct flash_area *, uint32_t off, uint32_t len);
 uint8_t flash_area_align(const struct flash_area *);
 /*< What is value is read from erased flash bytes. */
 uint8_t flash_area_erased_val(const struct flash_area *);
-/*< Reads len bytes from off, and checks if the read data is erased. Returns
-    1 if empty (that is containing erased value), 0 if not-empty, and -1 on
-    failure. */
-int     flash_area_read_is_empty(const struct flash_area *fa, uint32_t off,
-                     void *dst, uint32_t len);
 /*< Given flash area ID, return info about sectors within the area. */
 int     flash_area_get_sectors(int fa_id, uint32_t *count,
                      struct flash_sector *sectors);

--- a/sim/mcuboot-sys/csupport/run.c
+++ b/sim/mcuboot-sys/csupport/run.c
@@ -334,29 +334,6 @@ int flash_area_erase(const struct flash_area *area, uint32_t off, uint32_t len)
     return sim_flash_erase(area->fa_device_id, area->fa_off + off, len);
 }
 
-int flash_area_read_is_empty(const struct flash_area *area, uint32_t off,
-        void *dst, uint32_t len)
-{
-    uint8_t i;
-    uint8_t *u8dst;
-    int rc;
-
-    BOOT_LOG_SIM("%s: area=%d, off=%x, len=%x", __func__, area->fa_id, off, len);
-
-    rc = sim_flash_read(area->fa_device_id, area->fa_off + off, dst, len);
-    if (rc) {
-        return -1;
-    }
-
-    for (i = 0, u8dst = (uint8_t *)dst; i < len; i++) {
-        if (u8dst[i] != sim_flash_erased_val(area->fa_device_id)) {
-            return 0;
-        }
-    }
-
-    return 1;
-}
-
 int flash_area_to_sectors(int idx, int *cnt, struct flash_area *ret)
 {
     uint32_t i;

--- a/sim/mcuboot-sys/csupport/storage/flash_map.h
+++ b/sim/mcuboot-sys/csupport/storage/flash_map.h
@@ -131,14 +131,6 @@ uint16_t flash_area_align(const struct flash_area *);
 uint8_t flash_area_erased_val(const struct flash_area *);
 
 /*
- * Reads len bytes from off, and checks if the read data is erased.
- *
- * Returns 1 if erased, 0 if non-erased, and -1 on failure.
- */
-int flash_area_read_is_empty(const struct flash_area *fa, uint32_t off,
-        void *dst, uint32_t len);
-
-/*
  * Given flash area ID, return info about sectors within the area.
  */
 int flash_area_get_sectors(int fa_id, uint32_t *count,


### PR DESCRIPTION
Removes the current `flash_area_read_is_empty` which lacked a bit of clarity in its naming and error handling, as well as requiring an extra API in the flash map, and switches to using an internal function `bootutil_buffer_is_erased`.
    
Code that was previously using `flash_area_read_is_empty` must now be updated to do a `flash_area_read` followed by a call to `bootutil_buffer_is_erased` with the read buffer.
    
The proposal was previously discussed here: https://github.com/zephyrproject-rtos/zephyr/pull/28519