### PR TITLE
workflows: run on PR only

### DIFF
--- a/.github/workflows/mynewt.yaml
+++ b/.github/workflows/mynewt.yaml
@@ -5,12 +5,8 @@ jobs:
   environment:
     name: Mynewt build
     runs-on: ubuntu-latest
-    env:
-      MULTI_FEATURES: ${{ matrix.features }}
     steps:
     - uses: actions/checkout@v2
-      with:
-        submodules: recursive
     - name: Print the environment
       run: |
         uname -a

--- a/.github/workflows/mynewt.yaml
+++ b/.github/workflows/mynewt.yaml
@@ -1,8 +1,5 @@
 # For development, trigger this on any push.
-on: [push, pull_request]
-
-# Eventually, we'll want to limit this to pull requests.
-# on: ???
+on: [pull_request]
 
 jobs:
   environment:

--- a/.github/workflows/sim.yaml
+++ b/.github/workflows/sim.yaml
@@ -7,15 +7,18 @@ jobs:
       matrix:
         features:
         - "sig-ecdsa,sig-ed25519,enc-kw,bootstrap"
-        - ",sig-rsa,sig-rsa3072,overwrite-only,validate-primary-slot,swap-move"
-        - "enc-rsa,enc-ec256,enc-x25519"
+        - "sig-rsa,sig-rsa3072,overwrite-only,validate-primary-slot,swap-move"
+        - "enc-rsa"
+        - "enc-ec256"
+        - "enc-x25519"
         - "sig-rsa overwrite-only large-write,sig-ecdsa overwrite-only large-write,multiimage overwrite-only large-write"
         - "sig-rsa validate-primary-slot,sig-ecdsa validate-primary-slot,sig-rsa multiimage validate-primary-slot"
         - "enc-kw overwrite-only large-write,enc-rsa overwrite-only large-write"
         - "sig-rsa enc-rsa validate-primary-slot,swap-move enc-rsa sig-rsa validate-primary-slot"
         - "sig-rsa enc-kw validate-primary-slot bootstrap,sig-ed25519 enc-x25519 validate-primary-slot"
         - "sig-ecdsa enc-kw validate-primary-slot"
-        - "sig-rsa validate-primary-slot overwrite-only large-write,sig-ecdsa enc-ec256 validate-primary-slot"
+        - "sig-rsa validate-primary-slot overwrite-only large-write"
+        - "sig-ecdsa enc-ec256 validate-primary-slot"
         - "sig-rsa validate-primary-slot overwrite-only downgrade-prevention"
     name: Sim
     runs-on: ubuntu-latest

--- a/.github/workflows/sim.yaml
+++ b/.github/workflows/sim.yaml
@@ -1,8 +1,5 @@
 # For development, trigger this on any push.
-on: [push, pull_request]
-
-# Eventually, we'll want to limit this to pull requests.
-# on: ???
+on: [pull_request]
 
 jobs:
   environment:

--- a/.github/workflows/sim.yaml
+++ b/.github/workflows/sim.yaml
@@ -17,7 +17,7 @@ jobs:
         - "sig-ecdsa enc-kw validate-primary-slot"
         - "sig-rsa validate-primary-slot overwrite-only large-write,sig-ecdsa enc-ec256 validate-primary-slot"
         - "sig-rsa validate-primary-slot overwrite-only downgrade-prevention"
-    name: Environment report
+    name: Sim
     runs-on: ubuntu-latest
     env:
       MULTI_FEATURES: ${{ matrix.features }}


### PR DESCRIPTION
Remove option to run on push because it is triggering two runs for each test for all PRs.