### PR TITLE
cypress: Disable entering deep sleep if no boot/upgrade images found in MCUBootApp

### DIFF
--- a/boot/cypress/platforms/retarget_io_pdl/cy_retarget_io_pdl.c
+++ b/boot/cypress/platforms/retarget_io_pdl/cy_retarget_io_pdl.c
@@ -243,6 +243,23 @@ cy_rslt_t cy_retarget_io_pdl_init(uint32_t baudrate)
     return result;
 }
 
+/**
+ * @brief Wait while UART completes transfer. Try for tries_count times -
+ *        once each 10 millisecons.
+ */
+void cy_retarget_io_wait_tx_complete(CySCB_Type *base, uint32_t tries_count)
+{
+    while(tries_count > 0)
+    {
+        if (!Cy_SCB_UART_IsTxComplete(base)) {
+            Cy_SysLib_DelayCycles(10 * cy_delayFreqKhz);
+            tries_count -= 1;
+        } else {
+            return;
+        }
+    }
+}
+
 void cy_retarget_io_pdl_deinit()
 {
     Cy_SCB_UART_DeInit(CYBSP_UART_HW);

--- a/boot/cypress/platforms/retarget_io_pdl/cy_retarget_io_pdl.h
+++ b/boot/cypress/platforms/retarget_io_pdl/cy_retarget_io_pdl.h
@@ -52,6 +52,8 @@ extern "C" {
 
 cy_rslt_t cy_retarget_io_pdl_init(uint32_t baudrate);
 
+void cy_retarget_io_wait_tx_complete(CySCB_Type *base, uint32_t tries_count);
+
 void cy_retarget_io_pdl_deinit(void);
 
 #if defined(__cplusplus)


### PR DESCRIPTION
Entering deep sleep on CM0 without valid application on CM4 caused pyocd error while programming. This fix disables entering deep sleep mode on CM0 if no valid applications found for boot. Waiting for uart complete tx reworked. Code refactoring

Signed-off-by: Roman Okhrimenko <roman.okhrimenko@cypress.com>