### PR TITLE
Add ifdefs in crypto abstract function for ec256 to enable compilation when mbedtls used as backend

### DIFF
--- a/boot/bootutil/include/bootutil/crypto/ecdsa_p256.h
+++ b/boot/bootutil/include/bootutil/crypto/ecdsa_p256.h
@@ -13,7 +13,8 @@
 #include "mcuboot_config/mcuboot_config.h"
 
 #if (defined(MCUBOOT_USE_TINYCRYPT) + \
-     defined(MCUBOOT_USE_CC310)) != 1
+     defined(MCUBOOT_USE_CC310) + \
+     defined(MCUBOOT_USE_MBED_TLS)) != 1
     #error "One crypto backend must be defined: either CC310 or TINYCRYPT"
 #endif
 

--- a/boot/bootutil/src/image_ec256.c
+++ b/boot/bootutil/src/image_ec256.c
@@ -29,6 +29,8 @@
 #include "mcuboot_config/mcuboot_config.h"
 
 #ifdef MCUBOOT_SIGN_EC256
+/*TODO: remove this after cypress port mbedtls to abstract crypto api */
+#if defined (MCUBOOT_USE_TINYCRYPT) || defined (MCUBOOT_USE_CC310)
 #include "bootutil/sign_key.h"
 
 #include "mbedtls/oid.h"
@@ -182,4 +184,5 @@ bootutil_verify_sig(uint8_t *hash, uint32_t hlen, uint8_t *sig, size_t slen,
     return rc;
 }
 
+#endif /* MCUBOOT_USE_TINYCRYPT || defined MCUBOOT_USE_CC310 */
 #endif /* MCUBOOT_SIGN_EC256 */


### PR DESCRIPTION
Cypress use `MCUBOOT_USE_MBED_TLS` backend for crypto operation and `MCUBOOT_SIGN_EC256 ` algo. After recent change https://github.com/JuulLabs-OSS/mcuboot/pull/798 where abstraction of crypto functions was introduced, this combination is no longer work and `cypress` code can not be compiled.

This fix puts back ifdef `MCUBOOT_USE_TINYCRYPT` or `MCUBOOT_USE_CC310` in `image_ec256p.c` to exclude new implementation from build if `MCUBOOT_USE_MBED_TLS` and `MCUBOOT_SIGN_EC256` are defined in mcuboot_config.h until `cypress` port mbedtls backend to new abstraction crypto.
 
Signed-off-by: Roman Okhrimenko <roman.okhrimenko@cypress.com>