### PR TITLE
sim: add bootstrap test

### DIFF
--- a/.github/workflows/sim.yaml
+++ b/.github/workflows/sim.yaml
@@ -14,7 +14,7 @@ jobs:
         - "sig-rsa overwrite-only large-write,sig-ecdsa overwrite-only large-write,multiimage overwrite-only large-write"
         - "sig-rsa validate-primary-slot,sig-ecdsa validate-primary-slot,sig-rsa multiimage validate-primary-slot"
         - "enc-kw overwrite-only large-write,enc-rsa overwrite-only large-write"
-        - "sig-rsa enc-rsa validate-primary-slot,swap-move enc-rsa sig-rsa validate-primary-slot"
+        - "sig-rsa enc-rsa validate-primary-slot,swap-move enc-rsa sig-rsa validate-primary-slot bootstrap"
         - "sig-rsa enc-kw validate-primary-slot bootstrap,sig-ed25519 enc-x25519 validate-primary-slot"
         - "sig-ecdsa enc-kw validate-primary-slot"
         - "sig-rsa validate-primary-slot overwrite-only large-write"

--- a/boot/bootutil/include/bootutil/caps.h
+++ b/boot/bootutil/include/bootutil/caps.h
@@ -46,6 +46,7 @@ uint32_t bootutil_get_caps(void);
 #define BOOTUTIL_CAP_SWAP_USING_MOVE        (1<<11)
 #define BOOTUTIL_CAP_DOWNGRADE_PREVENTION   (1<<12)
 #define BOOTUTIL_CAP_ENC_X25519             (1<<13)
+#define BOOTUTIL_CAP_BOOTSTRAP              (1<<14)
 
 /*
  * Query the number of images this bootloader is configured for.  This

--- a/boot/bootutil/src/caps.c
+++ b/boot/bootutil/src/caps.c
@@ -65,6 +65,9 @@ uint32_t bootutil_get_caps(void)
 #if defined(MCUBOOT_DOWNGRADE_PREVENTION)
     res |= BOOTUTIL_CAP_DOWNGRADE_PREVENTION;
 #endif
+#if defined(MCUBOOT_BOOTSTRAP)
+    res |= BOOTUTIL_CAP_BOOTSTRAP;
+#endif
 
     return res;
 }

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -1636,11 +1636,11 @@ boot_prepare_image_for_update(struct boot_loader_state *state,
 
                 if (rc == 0 || fih_not_eq(fih_rc, FIH_SUCCESS)) {
 
-                    rc = boot_img_hdr(state, BOOT_SECONDARY_SLOT)->ih_magic == IMAGE_MAGIC;
+                    rc = (boot_img_hdr(state, BOOT_SECONDARY_SLOT)->ih_magic == IMAGE_MAGIC) ? 1: 0;
                     FIH_CALL(boot_validate_slot, fih_rc,
                              state, BOOT_SECONDARY_SLOT, bs);
 
-                    if (rc == 0 && fih_eq(fih_rc, FIH_SUCCESS)) {
+                    if (rc == 1 && fih_eq(fih_rc, FIH_SUCCESS)) {
                         /* Set swap type to REVERT to overwrite the primary
                          * slot with the image contained in secondary slot
                          * and to trigger the explicit setting of the

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -1566,7 +1566,14 @@ boot_prepare_image_for_update(struct boot_loader_state *state,
          * have been updated in the previous function call.
          */
         rc = boot_read_image_headers(state, !boot_status_is_reset(bs), bs);
+#ifdef MCUBOOT_BOOTSTRAP
+        /* When bootstrapping it's OK to not have image magic in the primary slot */
+        if (rc != 0 && (BOOT_CURR_IMG(state) != BOOT_PRIMARY_SLOT ||
+                boot_check_header_erased(state, BOOT_PRIMARY_SLOT) != 0)) {
+#else
         if (rc != 0) {
+#endif
+
             /* Continue with next image if there is one. */
             BOOT_LOG_WRN("Failed reading image headers; Image=%u",
                     BOOT_CURR_IMG(state));

--- a/sim/mcuboot-sys/build.rs
+++ b/sim/mcuboot-sys/build.rs
@@ -39,6 +39,7 @@ fn main() {
 
     if bootstrap {
         conf.define("MCUBOOT_BOOTSTRAP", None);
+        conf.define("MCUBOOT_OVERWRITE_ONLY_FAST", None);
     }
 
     if validate_primary_slot {
@@ -121,7 +122,6 @@ fn main() {
 
     if overwrite_only {
         conf.define("MCUBOOT_OVERWRITE_ONLY", None);
-        conf.define("MCUBOOT_OVERWRITE_ONLY_FAST", None);
     }
 
     if swap_move {

--- a/sim/mcuboot-sys/csupport/run.c
+++ b/sim/mcuboot-sys/csupport/run.c
@@ -42,7 +42,7 @@ extern int sim_flash_read(uint8_t flash_id, uint32_t offset, uint8_t *dest,
         uint32_t size);
 extern int sim_flash_write(uint8_t flash_id, uint32_t offset, const uint8_t *src,
         uint32_t size);
-extern uint8_t sim_flash_align(uint8_t flash_id);
+extern uint16_t sim_flash_align(uint8_t flash_id);
 extern uint8_t sim_flash_erased_val(uint8_t flash_id);
 
 struct sim_context {
@@ -202,7 +202,7 @@ done:
 #endif
 }
 
-uint8_t flash_area_align(const struct flash_area *area)
+uint16_t flash_area_align(const struct flash_area *area)
 {
     return sim_flash_align(area->fa_device_id);
 }

--- a/sim/mcuboot-sys/csupport/storage/flash_map.h
+++ b/sim/mcuboot-sys/csupport/storage/flash_map.h
@@ -123,7 +123,7 @@ int flash_area_erase(const struct flash_area *, uint32_t off, uint32_t len);
 /*
  * Alignment restriction for flash writes.
  */
-uint8_t flash_area_align(const struct flash_area *);
+uint16_t flash_area_align(const struct flash_area *);
 
 /*
  * What is value is read from erased flash bytes.

--- a/sim/mcuboot-sys/src/api.rs
+++ b/sim/mcuboot-sys/src/api.rs
@@ -21,7 +21,7 @@ use std::{
 pub type FlashMap = HashMap<u8, FlashPtr>;
 
 pub struct FlashParamsStruct {
-    align: u8,
+    align: u16,
     erased_val: u8,
 }
 
@@ -81,7 +81,7 @@ thread_local! {
 pub unsafe fn set_flash(dev_id: u8, dev: &mut dyn Flash) {
     THREAD_CTX.with(|ctx| {
         ctx.borrow_mut().flash_params.insert(dev_id, FlashParamsStruct {
-            align: dev.align() as u8,
+            align: dev.align() as u16,
             erased_val: dev.erased_val(),
         });
         let dev: &'static mut dyn Flash = mem::transmute(dev);
@@ -179,7 +179,7 @@ pub extern fn sim_flash_write(dev_id: u8, offset: u32, src: *const u8, size: u32
 }
 
 #[no_mangle]
-pub extern fn sim_flash_align(id: u8) -> u8 {
+pub extern fn sim_flash_align(id: u8) -> u16 {
     THREAD_CTX.with(|ctx| {
         ctx.borrow().flash_params.get(&id).unwrap().align
     })

--- a/sim/src/caps.rs
+++ b/sim/src/caps.rs
@@ -24,6 +24,7 @@ pub enum Caps {
     SwapUsingMove        = (1 << 11),
     DowngradePrevention  = (1 << 12),
     EncX25519            = (1 << 13),
+    Bootstrap            = (1 << 14),
 }
 
 impl Caps {

--- a/sim/tests/core.rs
+++ b/sim/tests/core.rs
@@ -48,6 +48,7 @@ macro_rules! sim_test {
 
 sim_test!(bad_secondary_slot, make_bad_secondary_slot_image(), run_signfail_upgrade());
 sim_test!(secondary_trailer_leftover, make_erased_secondary_image(), run_secondary_leftover_trailer());
+sim_test!(bootstrap, make_bootstrap_image(), run_bootstrap());
 sim_test!(norevert_newimage, make_no_upgrade_image(&NO_DEPS), run_norevert_newimage());
 sim_test!(basic_revert, make_image(&NO_DEPS, true), run_basic_revert());
 sim_test!(revert_with_fails, make_image(&NO_DEPS, false), run_revert_with_fails());


### PR DESCRIPTION
This should fix bootstrap in swap-move along with other fixes.

@d3zd3z After some issues I've found working on this PR, I think we should just remove the `MCUBOOT_OVERWRITE_ONLY_FAST` option and make it the default behavior when doing overwrite-only, what do you think?

Fixes #706, #738 