### PR TITLE
boot: zephyr: Disable HW stack protection

### DIFF
--- a/boot/zephyr/prj.conf
+++ b/boot/zephyr/prj.conf
@@ -33,3 +33,5 @@ CONFIG_FLASH=y
 CONFIG_LOG=y
 ### Ensure Zephyr logging changes don't use more resources
 CONFIG_LOG_DEFAULT_LEVEL=0
+
+CONFIG_HW_STACK_PROTECTION=n


### PR DESCRIPTION
Some Zephyr boards enable HW stack protection by default, which
propagates in mcuboot build. Bootloader works fine with that option, but
the problem arises when we jump to application code. HW stack protection
catches application code during early init, which results in
"unresponsive" application.

Disable HW stack protection, so it doesn't make any harm for application
code.

Signed-off-by: Marcin Niestroj <m.niestroj@grinn-global.com>