### PR TITLE
bootutil: fix swap-move brick with padded image in primary slot

### DIFF
--- a/boot/bootutil/src/swap_move.c
+++ b/boot/bootutil/src/swap_move.c
@@ -315,13 +315,11 @@ boot_move_sector_up(int idx, uint32_t sz, struct boot_loader_state *state,
     old_off = boot_img_sector_off(state, BOOT_PRIMARY_SLOT, idx - 1);
 
     if (bs->idx == BOOT_STATUS_IDX_0) {
-        if (bs->source != BOOT_STATUS_SOURCE_PRIMARY_SLOT) {
-            rc = swap_erase_trailer_sectors(state, fap_pri);
-            assert(rc == 0);
+        rc = swap_erase_trailer_sectors(state, fap_pri);
+        assert(rc == 0);
 
-            rc = swap_status_init(state, fap_pri, bs);
-            assert(rc == 0);
-        }
+        rc = swap_status_init(state, fap_pri, bs);
+        assert(rc == 0);
 
         rc = swap_erase_trailer_sectors(state, fap_sec);
         assert(rc == 0);


### PR DESCRIPTION
When the image in the primary slot is padded, the boot source is considered the primary slot; this results in skipping the typical initialization of the trailer, which ends up bricking the device. As it is fine to always initialize the trailer in the primary slot when starting a new upgrade the extra check was removed.

Should fix #829 when done.