### PR TITLE
Clean-up fault injection hardening header

### DIFF
--- a/boot/bootutil/include/bootutil/fault_injection_hardening.h
+++ b/boot/bootutil/include/bootutil/fault_injection_hardening.h
@@ -74,7 +74,7 @@
 #define FIH_ENABLE_GLOBAL_FAIL
 #define FIH_ENABLE_CFI
 
-#else
+#elif !defined(MCUBOOT_FIH_PROFILE_OFF)
 #define MCUBOOT_FIH_PROFILE_OFF
 #endif /* MCUBOOT_FIH_PROFILE */
 
@@ -141,7 +141,6 @@ void fih_panic_loop(void);
  * to skip.
  */
 #ifdef FIH_ENABLE_DELAY
-#include "bootutil/bootutil_log.h"
 
 /* Delaying logic, with randomness from a CSPRNG */
 __attribute__((always_inline)) inline

--- a/boot/bootutil/src/fault_injection_hardening_delay_rng_mbedtls.c
+++ b/boot/bootutil/src/fault_injection_hardening_delay_rng_mbedtls.c
@@ -13,8 +13,6 @@
 #include "mbedtls/ctr_drbg.h"
 #include "mbedtls/entropy.h"
 
-#include "bootutil/bootutil_log.h"
-
 /* Mbedtls implementation of the delay RNG. Can be replaced by any other RNG
  * implementation that is backed by an entropy source by altering these
  * functions. This is not provided as a header API and a C file implementation


### PR DESCRIPTION
Remove an unnecessary include and create conditionally
the MCUBOOT_FIH_PROFILE_OFF define to avoid redefinition
warnings.
