### PR TITLE
boot/zephyr: add nrfx watchdog kick during boot region copy

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -495,6 +495,16 @@ config MCUBOOT_HW_DOWNGRADE_PREVENTION
 
 endchoice
 
+config BOOT_WATCHDOG_FEED
+	bool "Feed the watchdog while doing swap"
+	default y if SOC_FAMILY_NRF
+	imply NRFX_WDT
+	imply NRFX_WDT0
+	imply NRFX_WDT1
+	help
+	  Enables implementation of MCUBOOT_WATCHDOG_FEED() macro which is
+	  used to feed watchdog while doing time consuming operations.
+
 endmenu
 
 config MCUBOOT_DEVICE_SETTINGS

--- a/boot/zephyr/include/mcuboot_config/mcuboot_config.h
+++ b/boot/zephyr/include/mcuboot_config/mcuboot_config.h
@@ -154,6 +154,7 @@
 
 #endif /* !__BOOTSIM__ */
 
+#if CONFIG_BOOT_WATCHDOG_FEED
 #if CONFIG_NRFX_WDT
 #include <nrfx_wdt.h>
 
@@ -180,12 +181,18 @@
 #endif /* defined(CONFIG_NRFX_WDT0) && defined(CONFIG_NRFX_WDT1) */
 
 #else /* CONFIG_NRFX_WDT */
-
+#warning "MCUBOOT_WATCHDOG_FEED() is no-op"
+/* No vendor implementation, no-op for historical reasons */
 #define MCUBOOT_WATCHDOG_FEED()         \
     do {                                \
-        /* TODO: to be implemented */   \
+    } while (0)
+#endif /* CONFIG_NRFX_WDT */
+#else  /* CONFIG_BOOT_WATCHDOG_FEED */
+/* Not enabled, no feed activity */
+#define MCUBOOT_WATCHDOG_FEED()         \
+    do {                                \
     } while (0)
 
-#endif /* CONFIG_NRFX_WDT */
+#endif /* CONFIG_BOOT_WATCHDOG_FEED */
 
 #endif /* __MCUBOOT_CONFIG_H__ */

--- a/boot/zephyr/include/mcuboot_config/mcuboot_config.h
+++ b/boot/zephyr/include/mcuboot_config/mcuboot_config.h
@@ -154,9 +154,38 @@
 
 #endif /* !__BOOTSIM__ */
 
+#if CONFIG_NRFX_WDT
+#include <nrfx_wdt.h>
+
+#define FEED_WDT_INST(id)                                    \
+    do {                                                     \
+        nrfx_wdt_t wdt_inst_##id = NRFX_WDT_INSTANCE(id);    \
+        for (uint8_t i = 0; i < NRF_WDT_CHANNEL_NUMBER; i++) \
+        {                                                    \
+            nrf_wdt_reload_request_set(wdt_inst_##id.p_reg,  \
+                (nrf_wdt_rr_register_t)(NRF_WDT_RR0 + i));   \
+        }                                                    \
+    } while (0)
+#if defined(CONFIG_NRFX_WDT0) && defined(CONFIG_NRFX_WDT1)
+#define MCUBOOT_WATCHDOG_FEED() \
+    do {                        \
+        FEED_WDT_INST(0);       \
+        FEED_WDT_INST(1);       \
+    } while (0)
+#elif defined(CONFIG_NRFX_WDT0)
+#define MCUBOOT_WATCHDOG_FEED() \
+    FEED_WDT_INST(0);
+#else /* defined(CONFIG_NRFX_WDT0) && defined(CONFIG_NRFX_WDT1) */
+#error "No NRFX WDT instances enabled"
+#endif /* defined(CONFIG_NRFX_WDT0) && defined(CONFIG_NRFX_WDT1) */
+
+#else /* CONFIG_NRFX_WDT */
+
 #define MCUBOOT_WATCHDOG_FEED()         \
     do {                                \
         /* TODO: to be implemented */   \
     } while (0)
+
+#endif /* CONFIG_NRFX_WDT */
 
 #endif /* __MCUBOOT_CONFIG_H__ */

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -313,6 +313,8 @@ void main(void)
     int rc;
     fih_int fih_rc = FIH_FAILURE;
 
+    MCUBOOT_WATCHDOG_FEED();
+
     BOOT_LOG_INF("Starting bootloader");
 
     os_heap_init();


### PR DESCRIPTION
copy of https://github.com/zephyrproject-rtos/mcuboot/pull/34

This fixes soft-bricks that we have seen as a result
of the bootloader being interrupted by the watchdog.

Signed-off-by: Emil Hammarstrom <emil.hammarstrom@assaabloy.com>
Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>