### PR TITLE
zephyr: remove flash_area_read_is_empty()

### DIFF
--- a/boot/zephyr/flash_map_extended.c
+++ b/boot/zephyr/flash_map_extended.c
@@ -115,24 +115,3 @@ uint8_t flash_area_erased_val(const struct flash_area *fap)
     (void)fap;
     return ERASED_VAL;
 }
-
-int flash_area_read_is_empty(const struct flash_area *fa, uint32_t off,
-        void *dst, uint32_t len)
-{
-    uint8_t i;
-    uint8_t *u8dst;
-    int rc;
-
-    rc = flash_area_read(fa, off, dst, len);
-    if (rc) {
-        return -1;
-    }
-
-    for (i = 0, u8dst = (uint8_t *)dst; i < len; i++) {
-        if (u8dst[i] != ERASED_VAL) {
-            return 0;
-        }
-    }
-
-    return 1;
-}


### PR DESCRIPTION
This function was drooped from MCUBoot's porting API.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>