### PR TITLE
zephyr: Kconfig: change default for MCUBOOT_CLEANUP_ARM_CODE

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -147,7 +147,20 @@ config BOOT_SIGNATURE_KEY_FILE
 config MCUBOOT_CLEANUP_ARM_CORE
 	bool "Perform core cleanup before chain-load the application"
 	depends on CPU_CORTEX_M
-	default y
+	default y if !ARCH_SUPPORTS_ARCH_HW_INIT
+	help
+	  This option instructs MCUboot to perform a clean-up of a set of
+	  architecture core HW registers before junping to the application
+	  firmware. The clean-up sets these registers to their warm-reset
+	  values as specified by the architecture.
+
+	  By default, this option is enabled only if the architecture does
+	  not have the functionality to perform such a register clean-up
+	  during application firmware boot.
+
+	  Zephyr applications on Cortex-M will perform this register clean-up
+	  by default, if they are chain-loadable by MCUboot, so MCUboot does
+	  not need to perform such a cleanup itself.
 
 config MBEDTLS_CFG_FILE
 	default "mcuboot-mbedtls-cfg.h"

--- a/boot/zephyr/arm_cleanup.c
+++ b/boot/zephyr/arm_cleanup.c
@@ -20,3 +20,15 @@ void cleanup_arm_nvic(void) {
 		NVIC->ICPR[i] = 0xFFFFFFFF;
 	}
 }
+
+__weak void z_arm_clear_arm_mpu_config(void)
+{
+	int i;
+
+	int num_regions =
+		((MPU->TYPE & MPU_TYPE_DREGION_Msk) >> MPU_TYPE_DREGION_Pos);
+
+	for (i = 0; i < num_regions; i++) {
+		ARM_MPU_ClrRegion(i);
+	}
+}

--- a/boot/zephyr/include/arm_cleanup.h
+++ b/boot/zephyr/include/arm_cleanup.h
@@ -12,4 +12,12 @@
  * Cleanup interrupt priority and interupt enable registers.
  */
 void cleanup_arm_nvic(void);
+
+#if defined(CONFIG_CPU_HAS_ARM_MPU)
+/**
+ * Cleanup all ARM MPU region configuration
+ */
+void z_arm_clear_arm_mpu_config(void);
+#endif
+
 #endif

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -131,12 +131,6 @@ static void do_boot(struct boot_rsp *rsp)
                                      rsp->br_image_off +
                                      rsp->br_hdr->ih_hdr_size);
 
-#ifdef CONFIG_CPU_CORTEX_M7
-    /* Disable instruction cache and data cache before chain-load the application */
-    SCB_DisableDCache();
-    SCB_DisableICache();
-#endif
-
     irq_lock();
 #ifdef CONFIG_SYS_CLOCK_EXISTS
     sys_clock_disable();
@@ -147,6 +141,15 @@ static void do_boot(struct boot_rsp *rsp)
 #endif
 #if CONFIG_MCUBOOT_CLEANUP_ARM_CORE
     cleanup_arm_nvic(); /* cleanup NVIC registers */
+
+#ifdef CONFIG_CPU_CORTEX_M7
+    /* Disable instruction cache and data cache before chain-load the application */
+    SCB_DisableDCache();
+    SCB_DisableICache();
+#endif
+
+#if CONFIG_CPU_HAS_ARM_MPU
+    z_arm_clear_arm_mpu_config();
 #endif
 
 #if defined(CONFIG_BUILTIN_STACK_GUARD) && \
@@ -157,6 +160,8 @@ static void do_boot(struct boot_rsp *rsp)
     __set_PSPLIM(0);
     __set_MSPLIM(0);
 #endif
+
+#endif /* CONFIG_MCUBOOT_CLEANUP_ARM_CORE */
 
 #ifdef CONFIG_BOOT_INTR_VEC_RELOC
 #if defined(CONFIG_SW_VECTOR_RELAY)

--- a/boot/zephyr/prj.conf
+++ b/boot/zephyr/prj.conf
@@ -33,5 +33,3 @@ CONFIG_FLASH=y
 CONFIG_LOG=y
 ### Ensure Zephyr logging changes don't use more resources
 CONFIG_LOG_DEFAULT_LEVEL=0
-
-CONFIG_HW_STACK_PROTECTION=n


### PR DESCRIPTION
Zephyr has introduced an option to perform the cleanup
of ARM core HW registers during early boot, when the
firmware is chain-loaded by MCUboot. Therefore, MCUboot
does not need to perform the same cleanup before jumping
to the application image. The patch relies on the fact
that building MCUboot with Zephyr implies loading also
a Zephyr-based application firmware. If this is not the
case, the application developer needs to enable the
MCUBOOT_CLEANUP_ARM_CODE Kconfig option manually, in the
project configuration.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>