### PR TITLE
boot/zephyr: make flash_area_erased_val() weak

### DIFF
--- a/boot/zephyr/flash_map_extended.c
+++ b/boot/zephyr/flash_map_extended.c
@@ -110,7 +110,7 @@ int flash_area_sector_from_off(off_t off, struct flash_sector *sector)
 }
 
 #define ERASED_VAL 0xff
-uint8_t flash_area_erased_val(const struct flash_area *fap)
+__weak uint8_t flash_area_erased_val(const struct flash_area *fap)
 {
     (void)fap;
     return ERASED_VAL;


### PR DESCRIPTION
The function was made week so zephyr-rtos implementation
will be used if available.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>