### PR TITLE
Fix upgrade issue in swap-move

### DIFF
--- a/boot/bootutil/src/swap_move.c
+++ b/boot/bootutil/src/swap_move.c
@@ -264,6 +264,7 @@ int
 swap_status_source(struct boot_loader_state *state)
 {
     struct boot_swap_state state_primary_slot;
+    struct boot_swap_state state_secondary_slot;
     int rc;
     uint8_t source;
     uint8_t image_index;
@@ -280,8 +281,15 @@ swap_status_source(struct boot_loader_state *state)
 
     BOOT_LOG_SWAP_STATE("Primary image", &state_primary_slot);
 
+    rc = boot_read_swap_state_by_id(FLASH_AREA_IMAGE_SECONDARY(image_index),
+            &state_secondary_slot);
+    assert(rc == 0);
+
+    BOOT_LOG_SWAP_STATE("Secondary image", &state_secondary_slot);
+
     if (state_primary_slot.magic == BOOT_MAGIC_GOOD &&
-            state_primary_slot.copy_done == BOOT_FLAG_UNSET) {
+            state_primary_slot.copy_done == BOOT_FLAG_UNSET &&
+            state_secondary_slot.magic != BOOT_MAGIC_GOOD) {
 
         source = BOOT_STATUS_SOURCE_PRIMARY_SLOT;
 

--- a/boot/bootutil/src/swap_move.c
+++ b/boot/bootutil/src/swap_move.c
@@ -315,11 +315,13 @@ boot_move_sector_up(int idx, uint32_t sz, struct boot_loader_state *state,
     old_off = boot_img_sector_off(state, BOOT_PRIMARY_SLOT, idx - 1);
 
     if (bs->idx == BOOT_STATUS_IDX_0) {
-        rc = swap_erase_trailer_sectors(state, fap_pri);
-        assert(rc == 0);
+        if (bs->source != BOOT_STATUS_SOURCE_PRIMARY_SLOT) {
+            rc = swap_erase_trailer_sectors(state, fap_pri);
+            assert(rc == 0);
 
-        rc = swap_status_init(state, fap_pri, bs);
-        assert(rc == 0);
+            rc = swap_status_init(state, fap_pri, bs);
+            assert(rc == 0);
+        }
 
         rc = swap_erase_trailer_sectors(state, fap_sec);
         assert(rc == 0);


### PR DESCRIPTION
A previous fix for allowing padded images in the primary slot, ended up causing an issue that would fail to upgrade under the right circumstances. The issue was caused when the following set of steps happened after an upgrade was detected:

1) trailer is erased on the primary slot
2) status is written to the primary slot
3) trailer is erased on the secondary slot
4) reset
1) trailer is erased on the primary slot
2) status partially written or not written to primary slot (no magic)
3) reset

This would result in images stored in the same slots they were initially, aka no upgrade, which would fail the simulator test for upgraded images.

The previous padded images fix was reverted and the status source was upgraded to also check that the secondary slot has a valid magic in it, so that there's never a circumstance where there is no trailer in any of the slots while an upgrade operation is being decided on.