### PR TITLE
zephyr: added ISB after cortex control was set

### DIFF
--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -182,6 +182,7 @@ static void do_boot(struct boot_rsp *rsp)
     __set_MSP(vt->msp);
 #if CONFIG_MCUBOOT_CLEANUP_ARM_CORE
     __set_CONTROL(0x00); /* application will configures core on its own */
+    __ISB();
 #endif
     ((void (*)(void))vt->reset)();
 }


### PR DESCRIPTION
After modifying the CONTROL register, ISB function should be
used to ensure the effect of the change applies to
subsequent code.
Due to the simple nature of the Cortex-M3, Cortex-M4, Cortex-M0+,
Cortex-M0, and Cortex-M1 pipeline,
omission of the ISB instruction does not cause any problem.
But might cause problem on a more advanced core.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>