### PR TITLE
zephyr/arm_cleanup: exclude z_arm_clear_arm_mpu_config() when no MPU

### DIFF
--- a/boot/zephyr/arm_cleanup.c
+++ b/boot/zephyr/arm_cleanup.c
@@ -21,6 +21,7 @@ void cleanup_arm_nvic(void) {
 	}
 }
 
+#if CONFIG_CPU_HAS_ARM_MPU
 __weak void z_arm_clear_arm_mpu_config(void)
 {
 	int i;
@@ -32,3 +33,4 @@ __weak void z_arm_clear_arm_mpu_config(void)
 		ARM_MPU_ClrRegion(i);
 	}
 }
+#endif


### PR DESCRIPTION
This function must be excluded from build when
core doesn't have MPU.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>